### PR TITLE
Fix for handling ReplyToAddress missing mapping in target address

### DIFF
--- a/src/NServiceBus.Transport.Bridge/EndpointRegistry.cs
+++ b/src/NServiceBus.Transport.Bridge/EndpointRegistry.cs
@@ -53,6 +53,9 @@ class EndpointRegistry : IEndpointRegistry
         throw new Exception($"No target endpoint dispatcher could be found for endpoint: {sourceEndpointName}");
     }
 
+    public bool TryTranslateToTargetAddress(string sourceAddress, out string targetAddress) =>
+        targetEndpointAddressMappings.TryGetValue(sourceAddress, out targetAddress);
+
     public string TranslateToTargetAddress(string sourceAddress)
     {
         if (targetEndpointAddressMappings.TryGetValue(sourceAddress, out var targetAddress))

--- a/src/NServiceBus.Transport.Bridge/IEndpointRegistry.cs
+++ b/src/NServiceBus.Transport.Bridge/IEndpointRegistry.cs
@@ -2,6 +2,8 @@
 {
     TargetEndpointDispatcher GetTargetEndpointDispatcher(string sourceEndpointName);
 
+    bool TryTranslateToTargetAddress(string sourceAddress, out string targetAddress);
+
     string TranslateToTargetAddress(string sourceAddress);
 
     string GetEndpointAddress(string endpointName);

--- a/src/NServiceBus.Transport.Bridge/MessageShovel.cs
+++ b/src/NServiceBus.Transport.Bridge/MessageShovel.cs
@@ -54,6 +54,7 @@ class MessageShovel
                 // This is a regular message sent between the endpoints on different sides of the bridge.
                 // The ReplyToAddress is transformed to allow for replies to be delivered
                 messageToSend.Headers[BridgeHeaders.Transfer] = transferDetails;
+
                 TransformAddressHeader(messageToSend, targetEndpointRegistry, Headers.ReplyToAddress);
             }
 
@@ -91,9 +92,14 @@ class MessageShovel
             return;
         }
 
-        var targetSpecificReplyToAddress = targetEndpointRegistry.TranslateToTargetAddress(headerValue);
+        if (!targetEndpointRegistry.TryTranslateToTargetAddress(headerValue, out string targetAddress))
+        {
+            messageToSend.Headers.Remove(headerKey);
+            logger.LogWarning($"Unable to find translation for {headerKey}:{headerValue}");
+            return;
+        }
 
-        messageToSend.Headers[headerKey] = targetSpecificReplyToAddress;
+        messageToSend.Headers[headerKey] = targetAddress;
     }
 
     readonly ILogger<MessageShovel> logger;


### PR DESCRIPTION
When a producer sends a command, a consumer processes it, and then raises an event that is intercepted by a second consumer. The second consumer processes the event and raises another event, which the bridge is listening to. In this case, the ReplyToAddress header contains the address of the last consumer, which the bridge is not aware of. Consequently, an exception is thrown when the bridge attempts to translate it into the target address. My modification ensures that in these situations, the header is removed, and a warning log is written.