### PR TITLE
Log a warning with the original exception message when truncating the exception message

### DIFF
--- a/src/NServiceBus.MessagingBridge/RawEndpoints/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.MessagingBridge/RawEndpoints/ExceptionHeaderHelper.cs
@@ -3,9 +3,13 @@
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using NServiceBus.Logging;
 
     static class ExceptionHeaderHelper
     {
+        const int MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS = 16384;
+        static readonly ILog Logger = LogManager.GetLogger(typeof(ExceptionHeaderHelper));
+
         public static void SetExceptionHeaders(Dictionary<string, string> headers, Exception e)
         {
             headers["NServiceBus.MessagingBridge.ExceptionInfo.ExceptionType"] = e.GetType().FullName;
@@ -15,8 +19,17 @@
                 headers["NServiceBus.ExceptionInfo.InnerExceptionType"] = e.InnerException.GetType().FullName;
             }
 
+            var exceptionMessage = e.GetMessage();
+
+            if (exceptionMessage.Length > MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS)
+            {
+                Logger.WarnFormat($"Truncating exception message to {MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS:N0} characters to prevent too large headers to be rejected by transport. Original message:\n{0}", exceptionMessage);
+                exceptionMessage = exceptionMessage.Truncate(MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS);
+                throw new Exception(exceptionMessage);
+            }
+
             headers["NServiceBus.MessagingBridge.ExceptionInfo.HelpLink"] = e.HelpLink;
-            headers["NServiceBus.MessagingBridge.ExceptionInfo.Message"] = e.GetMessage().Truncate(16384);
+            headers["NServiceBus.MessagingBridge.ExceptionInfo.Message"] = exceptionMessage;
             headers["NServiceBus.MessagingBridge.ExceptionInfo.Source"] = e.Source;
             headers["NServiceBus.MessagingBridge.ExceptionInfo.StackTrace"] = e.ToString();
             headers["NServiceBus.MessagingBridge.TimeOfFailure"] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);


### PR DESCRIPTION
Log a warning with the original exception message when truncating the exception message.

There doesn't seem to be a test that hits this logic. It's invoked via `RawEndpointErrorHandlingPolicy` which lacks tests. 