### PR TITLE
Transfer failures fails when assigning 'NServiceBus.MessagingBridge.FailedQ' header if header already exists

### DIFF
--- a/src/AcceptanceTests/Shared/TransferFailureTests.cs
+++ b/src/AcceptanceTests/Shared/TransferFailureTests.cs
@@ -51,7 +51,7 @@ public class TransferFailureTests : BridgeAcceptanceTest
                 .When(c => c.EndpointsStarted, async (session, c) =>
                 {
                     var opts = new SendOptions();
-                    opts.SetHeader("NServiceBus.MessagingBridge.FailedQ", ReceiveDummyQueue);
+                    opts.SetHeader(FailedQHeader, ReceiveDummyQueue);
                     opts.SetHeader(FakeShovelHeader.FailureHeader, string.Empty);
                     await session.Send(new FaultyMessage(), opts);
                 }))

--- a/src/AcceptanceTests/Shared/TransferFailureTests.cs
+++ b/src/AcceptanceTests/Shared/TransferFailureTests.cs
@@ -42,6 +42,37 @@ public class TransferFailureTests : BridgeAcceptanceTest
             $"Failed message headers does not contain {FailedQHeader}");
     }
 
+    [Test]
+    public async Task Should_add_failedq_header_when_transfer_fails_for_subsequent_failures()
+    {
+        var ctx = await Scenario.Define<Context>()
+            .WithEndpoint<ErrorSpy>()
+            .WithEndpoint<Sender>(b => b
+                .When(c => c.EndpointsStarted, async (session, c) =>
+                {
+                    var opts = new SendOptions();
+                    opts.SetHeader("NServiceBus.MessagingBridge.FailedQ", ReceiveDummyQueue);
+                    opts.SetHeader(FakeShovelHeader.FailureHeader, string.Empty);
+                    await session.Send(new FaultyMessage(), opts);
+                }))
+            .WithBridge(bridgeConfiguration =>
+            {
+                var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
+                bridgeTransport.AddTestEndpoint<Sender>();
+                bridgeConfiguration.AddTransport(bridgeTransport);
+                bridgeTransport.ErrorQueue = ErrorQueue;
+
+                var subscriberEndpoint = new BridgeEndpoint(ReceiveDummyQueue);
+                bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
+            })
+            .Done(c => c.MessageFailed)
+            .Run();
+
+        Assert.IsTrue(ctx.MessageFailed, "Message did not fail");
+        Assert.IsTrue(ctx.FailedMessageHeaders.ContainsKey(FailedQHeader),
+            $"Failed message headers does not contain {FailedQHeader}");
+    }
+
     public class Sender : EndpointConfigurationBuilder
     {
         public Sender() =>

--- a/src/NServiceBus.MessagingBridge/RawEndpoints/RawEndpointErrorHandlingPolicy.cs
+++ b/src/NServiceBus.MessagingBridge/RawEndpoints/RawEndpointErrorHandlingPolicy.cs
@@ -35,7 +35,7 @@ namespace NServiceBus.Raw
             headers.Remove(Headers.DelayedRetries);
             headers.Remove(Headers.ImmediateRetries);
 
-            headers.Add(BridgeHeaders.FailedQ, localAddress);
+            headers[BridgeHeaders.FailedQ] = localAddress;
             ExceptionHeaderHelper.SetExceptionHeaders(headers, errorContext.Exception);
 
             var transportOperations = new TransportOperations(new TransportOperation(outgoingMessage, new UnicastAddressTag(errorQueue)));


### PR DESCRIPTION
Resolves #280 which was introduced in https://github.com/Particular/NServiceBus.MessagingBridge/releases/tag/2.0.1

Setting of the `NServiceBus.MessagingBridge.FailedQ` header would fail if the header already exists due to using `.Add` which does does allow replacing an existing value.

