### PR TITLE
Enables the Bridge to shovel messages one-way

### DIFF
--- a/src/AcceptanceTests/Shared/MultipleLogicalPublishersForSameEvent.cs
+++ b/src/AcceptanceTests/Shared/MultipleLogicalPublishersForSameEvent.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.AcceptanceTesting;
+using NUnit.Framework;
+using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
+
+class MultipleLogicalPublishersForSameEvent : BridgeAcceptanceTest
+{
+    [Test]
+    public async Task Subscriber_should_get_the_event()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithBridge(bridgeConfiguration =>
+            {
+                bridgeConfiguration.DoNotEnforceBestPractices();
+
+                var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
+
+                bridgeTransport.AddTestEndpoint<PublisherOne>();
+                bridgeTransport.AddTestEndpoint<PublisherTwo>();
+                bridgeConfiguration.AddTransport(bridgeTransport);
+
+                var subscriberEndpoint = new BridgeEndpoint(Conventions.EndpointNamingConvention(typeof(Subscriber)));
+
+                subscriberEndpoint.RegisterPublisher<MyEvent>(
+                    Conventions.EndpointNamingConvention(typeof(PublisherOne)));
+                subscriberEndpoint.RegisterPublisher<MyEvent>(
+                    Conventions.EndpointNamingConvention(typeof(PublisherTwo)));
+                bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
+            })
+            .WithEndpoint<PublisherOne>(b => b
+                .When(c => TransportBeingTested.SupportsPublishSubscribe || c.SubscriberPublisherOneSubscribed,
+                    (session, c) =>
+                    {
+                        return session.Publish(new MyEvent());
+                    }))
+            .WithEndpoint<PublisherTwo>(b => b
+                .When(c => TransportBeingTested.SupportsPublishSubscribe || c.SubscriberPublisherTwoSubscribed,
+                    (session, c) =>
+                    {
+                        return session.Publish(new MyEvent());
+                    }))
+            .WithEndpoint<Subscriber>()
+            .Done(c => c.SubscriberGotEventFromPublisherOne && c.SubscriberGotEventFromPublisherTwo)
+            .Run();
+    }
+
+    public class Context : ScenarioContext
+    {
+        public bool SubscriberPublisherOneSubscribed { get; set; }
+        public bool SubscriberPublisherTwoSubscribed { get; set; }
+        public bool SubscriberGotEventFromPublisherOne { get; set; }
+        public bool SubscriberGotEventFromPublisherTwo { get; set; }
+    }
+
+    class PublisherOne : EndpointConfigurationBuilder
+    {
+        public PublisherOne()
+        {
+            EndpointSetup<DefaultPublisher>(c =>
+            {
+                c.OnEndpointSubscribed<Context>((_, ctx) =>
+                {
+                    ctx.SubscriberPublisherOneSubscribed = true;
+                });
+            });
+        }
+    }
+
+    class PublisherTwo : EndpointConfigurationBuilder
+    {
+        public PublisherTwo()
+        {
+            EndpointSetup<DefaultPublisher>(c =>
+            {
+                c.OnEndpointSubscribed<Context>((_, ctx) =>
+                {
+                    ctx.SubscriberPublisherTwoSubscribed = true;
+                });
+            });
+        }
+    }
+
+    class Subscriber : EndpointConfigurationBuilder
+    {
+        public Subscriber()
+        {
+            EndpointSetup<DefaultTestServer>();
+        }
+
+        public class MessageHandler : IHandleMessages<MyEvent>
+        {
+            Context context;
+
+            public MessageHandler(Context context) => this.context = context;
+
+            public Task Handle(MyEvent message, IMessageHandlerContext handlerContext)
+            {
+                string originatingEndpoint = handlerContext.MessageHeaders[Headers.OriginatingEndpoint];
+                switch (originatingEndpoint)
+                {
+                    case "Multiplelogicalpublishersforsameevent.PublisherOne":
+                        context.SubscriberGotEventFromPublisherOne = true;
+                        break;
+                    case "Multiplelogicalpublishersforsameevent.PublisherTwo":
+                        context.SubscriberGotEventFromPublisherTwo = true;
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unknown originating endpoint: {originatingEndpoint}");
+                }
+
+                return Task.FromResult(0);
+            }
+        }
+    }
+
+    public class MyEvent : IEvent
+    {
+    }
+}

--- a/src/NServiceBus.MessagingBridge/Configuration/BridgeConfiguration.cs
+++ b/src/NServiceBus.MessagingBridge/Configuration/BridgeConfiguration.cs
@@ -54,7 +54,12 @@ namespace NServiceBus
             if (tranportsWithNoEndpoints.Any())
             {
                 var endpointNames = string.Join(", ", tranportsWithNoEndpoints);
-                throw new InvalidOperationException($"At least one endpoint needs to be configured for transport(s): {endpointNames}");
+                logger.LogWarning($"The following transport(s) have no endpoints: {endpointNames}");
+            }
+
+            if (tranportsWithNoEndpoints.Count() == transportConfigurations.Count)
+            {
+                throw new InvalidOperationException($"No transport has an endpoint configured. At least one transport should have an endpoint to be able to bridge messages");
             }
 
             var allEndpoints = transportConfigurations

--- a/src/NServiceBus.MessagingBridge/Configuration/BridgeConfiguration.cs
+++ b/src/NServiceBus.MessagingBridge/Configuration/BridgeConfiguration.cs
@@ -59,7 +59,7 @@ namespace NServiceBus
 
             if (tranportsWithNoEndpoints.Count() == transportConfigurations.Count)
             {
-                throw new InvalidOperationException($"No transport has an endpoint configured. At least one transport should have an endpoint to be able to bridge messages");
+                throw new InvalidOperationException("No transport has an endpoint configured. At least one transport should have an endpoint to be able to bridge messages");
             }
 
             var allEndpoints = transportConfigurations

--- a/src/NServiceBus.MessagingBridge/Configuration/BridgeConfiguration.cs
+++ b/src/NServiceBus.MessagingBridge/Configuration/BridgeConfiguration.cs
@@ -54,7 +54,7 @@ namespace NServiceBus
             if (tranportsWithNoEndpoints.Any())
             {
                 var endpointNames = string.Join(", ", tranportsWithNoEndpoints);
-                logger.LogWarning($"The following transport(s) have no endpoints: {endpointNames}");
+                logger.LogWarning("The following transport(s) have no endpoints: {endpointNames}", endpointNames);
             }
 
             if (tranportsWithNoEndpoints.Count() == transportConfigurations.Count)

--- a/src/NServiceBus.MessagingBridge/Configuration/BridgeConfiguration.cs
+++ b/src/NServiceBus.MessagingBridge/Configuration/BridgeConfiguration.cs
@@ -113,32 +113,21 @@ namespace NServiceBus
 
             if (eventsWithMultiplePublishers.Any())
             {
-                var sb = new StringBuilder();
-
-                if (allowMultiplePublishersSameEvent)
-                {
-                    sb.Append(
-                        "The following subscriptions with multiple registered publishers are ignored as best practices are not enforced:\r");
-                }
-                else
-                {
-                    sb.Append(
-                        "Events can only be associated with a single publisher, please verify subscriptions for:\r");
-                }
+                var data = new StringBuilder();
 
                 foreach (var eventType in eventsWithMultiplePublishers)
                 {
                     var publishers = string.Join(", ", eventType.Select(e => e.Publisher));
-                    sb.Append($"- {eventType.Key}, registered publishers: {publishers}\r");
+                    data.Append($"- {eventType.Key}, registered publishers: {publishers}\r");
                 }
 
                 if (allowMultiplePublishersSameEvent)
                 {
-                    logger.LogWarning(sb.ToString());
+                    logger.LogWarning("The following subscriptions with multiple registered publishers are ignored as best practices are not enforced:\r{events}", data);
                 }
                 else
                 {
-                    throw new InvalidOperationException(sb.ToString());
+                    throw new InvalidOperationException("Events can only be associated with a single publisher, please verify subscriptions for:\r" + data);
                 }
             }
 

--- a/src/UnitTests/ApprovalFiles/APIApprovals.PublicApi.approved.txt
+++ b/src/UnitTests/ApprovalFiles/APIApprovals.PublicApi.approved.txt
@@ -6,6 +6,7 @@ namespace NServiceBus
     {
         public BridgeConfiguration() { }
         public void AddTransport(NServiceBus.BridgeTransport transportConfiguration) { }
+        public void DoNotEnforceBestPractices() { }
         public void RunInReceiveOnlyTransactionMode() { }
     }
     public class BridgeEndpoint

--- a/src/UnitTests/BridgeConfigurationTests.cs
+++ b/src/UnitTests/BridgeConfigurationTests.cs
@@ -1,9 +1,11 @@
-﻿using System;
+using System;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NServiceBus;
 using NServiceBus.Transport;
 using NUnit.Framework;
+using UnitTests;
 
 public class BridgeConfigurationTests
 {
@@ -158,6 +160,38 @@ public class BridgeConfigurationTests
     }
 
     [Test]
+    public void Subscriptions_for_same_event_can_have_different_publisher()
+    {
+        var configuration = new BridgeConfiguration();
+        configuration.DoNotEnforceBestPractices();
+
+        var someTransport = new BridgeTransport(new SomeTransport());
+
+        someTransport.HasEndpoint("Publisher");
+        someTransport.HasEndpoint("OtherEndpoint");
+        configuration.AddTransport(someTransport);
+
+        var someOtherTransport = new BridgeTransport(new SomeOtherTransport());
+
+        var subscriber1 = new BridgeEndpoint("Subscriber1");
+
+        subscriber1.RegisterPublisher<MyEvent>("Publisher");
+        someOtherTransport.HasEndpoint(subscriber1);
+
+        var subscriber2 = new BridgeEndpoint("Subscriber2");
+
+        subscriber1.RegisterPublisher<MyEvent>("OtherEndpoint");
+        someOtherTransport.HasEndpoint(subscriber2);
+        configuration.AddTransport(someOtherTransport);
+
+        FinalizeConfiguration(configuration);
+
+        Assert.Contains(
+            "The following subscriptions with multiple registered publishers are ignored as best practices are not enforced:\r- BridgeConfigurationTests+MyEvent, UnitTests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b50674d1e0c6ce54, registered publishers: Publisher, OtherEndpoint\r",
+            logger.logEntries);
+    }
+
+    [Test]
     public void Should_require_transports_of_the_same_type_to_be_uniquely_identifiable_by_name()
     {
         var configuration = new BridgeConfiguration();
@@ -280,7 +314,7 @@ public class BridgeConfigurationTests
 
     FinalizedBridgeConfiguration FinalizeConfiguration(BridgeConfiguration bridgeConfiguration)
     {
-        return bridgeConfiguration.FinalizeConfiguration(new NullLogger<BridgeConfiguration>());
+        return bridgeConfiguration.FinalizeConfiguration(logger);
     }
 
     class SomeScopeSupportingTransport : FakeTransport

--- a/src/UnitTests/BridgeConfigurationTests.cs
+++ b/src/UnitTests/BridgeConfigurationTests.cs
@@ -24,7 +24,7 @@ public class BridgeConfigurationTests
     }
 
     [Test]
-    public void At_least_on_endpoint_per_endpoint_should_be_configured()
+    public void At_least_one_transport_should_have_endpoints()
     {
         var configuration = new BridgeConfiguration();
 
@@ -33,8 +33,25 @@ public class BridgeConfigurationTests
 
         var ex = Assert.Throws<InvalidOperationException>(() => FinalizeConfiguration(configuration));
 
-        StringAssert.Contains("At least one", ex.Message);
-        StringAssert.Contains("some, someother", ex.Message);
+        Assert.AreEqual("No transport has an endpoint configured. At least one transport should have an endpoint to be able to bridge messages", ex.Message);
+    }
+
+    [Test]
+    public void Oneway_bridging_should_be_possible()
+    {
+        var configuration = new BridgeConfiguration();
+
+        configuration.AddTransport(new BridgeTransport(new SomeTransport()));
+
+        var transportWithEndpoint = new BridgeTransport(new SomeOtherTransport());
+        transportWithEndpoint.HasEndpoint("SomeEndpoint");
+        configuration.AddTransport(transportWithEndpoint);
+
+        FinalizeConfiguration(configuration);
+
+        Assert.Contains(
+            "The following transport(s) have no endpoints: some",
+            logger.logEntries);
     }
 
     [Test]

--- a/src/UnitTests/BridgeConfigurationTests.cs
+++ b/src/UnitTests/BridgeConfigurationTests.cs
@@ -342,5 +342,6 @@ public class BridgeConfigurationTests
     class MyEvent
     {
     }
-}
 
+    readonly FakeLogger<BridgeConfiguration> logger = new();
+}

--- a/src/UnitTests/FakeLoggerT.cs
+++ b/src/UnitTests/FakeLoggerT.cs
@@ -1,0 +1,20 @@
+﻿namespace UnitTests;
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+class FakeLogger<T> : ILogger<T>
+{
+    public readonly List<string> logEntries = new();
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+        Func<TState, Exception, string> formatter)
+    {
+        logEntries.Add(state.ToString());
+    }
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => throw new NotSupportedException();
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Fixes https://github.com/Particular/NServiceBus.MessagingBridge/issues/118

This makes 3 scenarios possible:

1. When moving messages from the cloud to on-premise (or vice-versa), endpoints only need to be configured on one side of the messaging bridge.
2. When hosting the bridge together with the endpoint, so that when the endpoint is migrated to the new side, the bridge for that endpoint is immediately removed upon deployment.
3. When configuring multiple (scaled out) bridges to shovel messages to certain endpoints, not always are endpoints on both sides of the bridge required.

The messaging bridge now only _warns_ if one `BridgeTransport` is without endpoints.
Only fails when not a single bridge transport has any endpoints configured.