### PR TITLE
Fix problems around ExceptionHeaderHelper

### DIFF
--- a/src/NServiceBus.MessagingBridge/BridgeHeaders.cs
+++ b/src/NServiceBus.MessagingBridge/BridgeHeaders.cs
@@ -2,4 +2,12 @@
 {
     public const string Transfer = "NServiceBus.Bridge.Transfer";
     public const string FailedQ = "NServiceBus.MessagingBridge.FailedQ";
+    public const string ExceptionInfoHelpLink = "NServiceBus.MessagingBridge.ExceptionInfo.HelpLink";
+    public const string ExceptionInfoSource = "NServiceBus.MessagingBridge.ExceptionInfo.Source";
+    public const string ExceptionInfoMessage = "NServiceBus.MessagingBridge.ExceptionInfo.Message";
+    public const string ExceptionInfoStackTrace = "NServiceBus.MessagingBridge.ExceptionInfo.StackTrace";
+    public const string ExceptionInfoExceptionType = "NServiceBus.MessagingBridge.ExceptionInfo.ExceptionType";
+    public const string ExceptionInfoInnerExceptionType = "NServiceBus.MessagingBridge.ExceptionInfo.InnerExceptionType";
+    public const string TimeOfFailure = "NServiceBus.MessagingBridge.TimeOfFailure";
+    public const string ExceptionInfoDataPrefix = "NServiceBus.MessagingBridge.ExceptionInfo.Data.";
 }

--- a/src/NServiceBus.MessagingBridge/RawEndpoints/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.MessagingBridge/RawEndpoints/ExceptionHeaderHelper.cs
@@ -23,14 +23,22 @@
 
             if (exceptionMessage.Length > MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS)
             {
-                Logger.WarnFormat($"Truncating exception message to {MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS:N0} characters to prevent too large headers to be rejected by transport. Original message:\n{{0}}", exceptionMessage);
+                Logger.WarnFormat($"Truncating exception message to {MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS:N0} characters to prevent too large headers to be rejected by transport. Original value:\n{{0}}", exceptionMessage);
                 exceptionMessage = exceptionMessage.Truncate(MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS);
+            }
+
+            var stackTrace = e.ToString();
+
+            if (stackTrace.Length > MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS)
+            {
+                Logger.WarnFormat($"Truncating stack trace message to {MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS:N0} characters to prevent too large headers to be rejected by transport. Original value:\n{{0}}", stackTrace);
+                stackTrace = stackTrace.Truncate(MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS);
             }
 
             headers["NServiceBus.MessagingBridge.ExceptionInfo.HelpLink"] = e.HelpLink;
             headers["NServiceBus.MessagingBridge.ExceptionInfo.Message"] = exceptionMessage;
             headers["NServiceBus.MessagingBridge.ExceptionInfo.Source"] = e.Source;
-            headers["NServiceBus.MessagingBridge.ExceptionInfo.StackTrace"] = e.ToString();
+            headers["NServiceBus.MessagingBridge.ExceptionInfo.StackTrace"] = stackTrace;
             headers["NServiceBus.MessagingBridge.TimeOfFailure"] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
 
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse

--- a/src/NServiceBus.MessagingBridge/RawEndpoints/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.MessagingBridge/RawEndpoints/ExceptionHeaderHelper.cs
@@ -23,9 +23,8 @@
 
             if (exceptionMessage.Length > MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS)
             {
-                Logger.WarnFormat($"Truncating exception message to {MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS:N0} characters to prevent too large headers to be rejected by transport. Original message:\n{0}", exceptionMessage);
+                Logger.WarnFormat($"Truncating exception message to {MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS:N0} characters to prevent too large headers to be rejected by transport. Original message:\n{{0}}", exceptionMessage);
                 exceptionMessage = exceptionMessage.Truncate(MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS);
-                throw new Exception(exceptionMessage);
             }
 
             headers["NServiceBus.MessagingBridge.ExceptionInfo.HelpLink"] = e.HelpLink;

--- a/src/NServiceBus.MessagingBridge/RawEndpoints/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.MessagingBridge/RawEndpoints/ExceptionHeaderHelper.cs
@@ -55,7 +55,16 @@
                 {
                     continue;
                 }
-                headers["NServiceBus.MessagingBridge.ExceptionInfo.Data." + entry.Key] = entry.Value.ToString();
+
+                var value = entry.Value.ToString();
+
+                if (value.Length > MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS)
+                {
+                    Logger.WarnFormat($"Truncating {entry.Key} to {MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS:N0} characters to prevent too large headers to be rejected by transport. Original value:\n{{0}}", stackTrace);
+                    value = value.Truncate(MAX_LENGTH_TO_PREVENT_TOO_LARGE_HEADERS);
+                }
+
+                headers["NServiceBus.MessagingBridge.ExceptionInfo.Data." + entry.Key] = value;
             }
         }
 

--- a/src/NServiceBus.MessagingBridge/RawEndpoints/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.MessagingBridge/RawEndpoints/ExceptionHeaderHelper.cs
@@ -32,9 +32,6 @@
             headers[ExceptionInfoStackTrace] = e.ToString();
             headers[TimeOfFailure] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
 
-            TruncateHeaderAndWarnIfNeeded(headers, ExceptionInfoMessage);
-            TruncateHeaderAndWarnIfNeeded(headers, ExceptionInfoStackTrace);
-
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
             if (e.Data == null)
             // ReSharper disable HeuristicUnreachableCode
@@ -57,6 +54,9 @@
             }
 
             var totalHeaderSize = headers.Sum(x => x.Key.Length + x.Value?.Length);
+
+            TruncateHeaderAndWarnIfNeeded(headers, ExceptionInfoMessage);
+            TruncateHeaderAndWarnIfNeeded(headers, ExceptionInfoStackTrace);
 
             if (IsInfoEnabled)
             {

--- a/src/UnitTests/ExceptionHeaderHelperFixture.cs
+++ b/src/UnitTests/ExceptionHeaderHelperFixture.cs
@@ -9,8 +9,6 @@ public class ExceptionHeaderHelperFixture
     [Test]
     public void When_exception_message_is_large_then_it_must_be_truncated()
     {
-        LogManager.Use<DefaultFactory>().Level(LogLevel.Debug);
-
         var headers = new Dictionary<string, string>();
         try
         {
@@ -28,8 +26,6 @@ public class ExceptionHeaderHelperFixture
                 {
                     Data = { { "b", new string('V', 20000) } }
                 };
-
-
             }
         }
         catch (Exception outer)

--- a/src/UnitTests/ExceptionHeaderHelperFixture.cs
+++ b/src/UnitTests/ExceptionHeaderHelperFixture.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using NServiceBus.Raw;
+using NUnit.Framework;
+
+public class ExceptionHeaderHelperFixture
+{
+    [Test]
+    public void When_exception_message_is_large_then_it_must_be_truncated()
+    {
+        var headers = new Dictionary<string, string>();
+        try
+        {
+            try
+            {
+                throw new Exception(new string('Y', 10000))
+                {
+                    Data = { { "a", new string('Z', 20000) } }
+                };
+            }
+            catch (Exception inner)
+            {
+
+                throw new Exception(new string('X', 10000), inner)
+                {
+                    Data = { { "b", new string('V', 20000) } }
+                };
+
+
+            }
+        }
+        catch (Exception outer)
+        {
+            ExceptionHeaderHelper.SetExceptionHeaders(headers, outer);
+
+            Assert.LessOrEqual(headers["NServiceBus.MessagingBridge.ExceptionInfo.Message"].Length, 16399, "Message");
+            Assert.LessOrEqual(headers["NServiceBus.MessagingBridge.ExceptionInfo.StackTrace"].Length, 16399, "Stacktrace");
+            Assert.LessOrEqual(headers["NServiceBus.MessagingBridge.ExceptionInfo.Data.b"].Length, 16399, "Stacktrace");
+        }
+    }
+}


### PR DESCRIPTION
0. Fix incorrect commit b9a9ad25c88a5c0ad6949c77cf7efb3bb4ce7f98 that is not yet part of a release
1. Previously truncated headers unnoticed, now logging as WARN
2. Now calculates the total sum of header keys + values and logging as WARN if it exceeds 32Kb characters
3. Now logging ANY header as INFO that has a value larger than 16Kb when INFO is enabled
4. Logging total sum of header keys + value characters as DEBUG when DEBUG is enabled