### PR TITLE
Spike: One-way BridgeEndpoint

### DIFF
--- a/src/NServiceBus.MessagingBridge/Configuration/BridgeEndpoint.cs
+++ b/src/NServiceBus.MessagingBridge/Configuration/BridgeEndpoint.cs
@@ -101,5 +101,14 @@
 
             public string Publisher { get; private set; }
         }
+
+        /// <summary>
+        /// Instructs the bridge to not bridge TO this endpoint and not create receive proxies on all other transports but only to allow sending FROM this endpoint to another transport endpoint.
+        /// </summary>
+        public bool OneWay
+        {
+            get;
+            set;
+        }
     }
 }

--- a/src/NServiceBus.MessagingBridge/StartableBridge.cs
+++ b/src/NServiceBus.MessagingBridge/StartableBridge.cs
@@ -40,6 +40,7 @@ class StartableBridge : IStartableBridge
                 var startableEndpointProxy = await endpointProxyFactory.CreateProxy(
                    endpointToSimulate,
                    transportConfiguration,
+                   endpointToSimulate.OneWay,
                    cancellationToken)
                    .ConfigureAwait(false);
 

--- a/src/UnitTests/ApprovalFiles/APIApprovals.PublicApi.approved.txt
+++ b/src/UnitTests/ApprovalFiles/APIApprovals.PublicApi.approved.txt
@@ -13,6 +13,7 @@ namespace NServiceBus
     {
         public BridgeEndpoint(string name) { }
         public BridgeEndpoint(string name, string queueAddress) { }
+        public bool OneWay { get; set; }
         public void RegisterPublisher(string eventTypeAssemblyQualifiedName, string publisher) { }
         public void RegisterPublisher(System.Type eventType, string publisher) { }
         public void RegisterPublisher<T>(string publisher) { }


### PR DESCRIPTION
- Resolves https://github.com/Particular/NServiceBus.MessagingBridge/issues/294
- Resolves https://github.com/Particular/NServiceBus.MessagingBridge/issues/118

## Example

```c#
var left = new BridgeTransport(new LearningTransport
{
    StorageDirectory = $"{LearningTransportInfrastructure.FindStoragePath()}.Left"
})
{
    Name = "left"
};

var right = new BridgeTransport(new LearningTransport
{
    StorageDirectory = $"{LearningTransportInfrastructure.FindStoragePath()}.Right"
})
{
    Name = "right"
};

var sender = new BridgeEndpoint("Receiver") { OneWay = true }; // Ensures no receive proxy is recreated on "right"
left.HasEndpoint(sender);

var receiver = new BridgeEndpoint("Receiver");
right.HasEndpoint(receiver);

bridgeConfiguration.AddTransport(left);
bridgeConfiguration.AddTransport(right);
```