### PR TITLE
GetNearestCaseInsensitiveMatch could throw when there are no mappings

### DIFF
--- a/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
+++ b/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
@@ -81,12 +81,11 @@ class EndpointRegistry : IEndpointRegistry
 
     static string GetNearestCaseInsensitiveMatch(string sourceEndpointName, IEnumerable<string> items)
     {
-        var results = new List<(int distance, string value)>();
         var calculator = new Levenshtein(sourceEndpointName.ToLower());
         var nearestMatch = items
             .OrderBy(x => calculator.DistanceFrom(x.ToLower()))
-            .First();
-        return nearestMatch;
+            .FirstOrDefault();
+        return nearestMatch ?? "(No mappings registered)";
     }
 
     public IEnumerable<ProxyRegistration> Registrations => registrations;

--- a/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
+++ b/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
@@ -50,7 +50,7 @@ class EndpointRegistry : IEndpointRegistry
             return endpointDispatcher;
         }
 
-        var nearestMatch = GetNearestCaseInsensitiveMatch(sourceEndpointName, targetEndpointDispatchers.Keys);
+        var nearestMatch = GetClosestMatchForExceptionMessage(sourceEndpointName, targetEndpointDispatchers.Keys);
 
         throw new Exception($"No target endpoint dispatcher could be found for endpoint: {sourceEndpointName}. Ensure names have correct casing as mappings are case-sensitive. Nearest configured match: {nearestMatch}");
     }
@@ -62,7 +62,7 @@ class EndpointRegistry : IEndpointRegistry
             return targetAddress;
         }
 
-        var nearestMatch = GetNearestCaseInsensitiveMatch(sourceAddress, targetEndpointAddressMappings.Keys);
+        var nearestMatch = GetClosestMatchForExceptionMessage(sourceAddress, targetEndpointAddressMappings.Keys);
 
         throw new Exception($"No target address mapping could be found for source address: {sourceAddress}. Ensure names have correct casing as mappings are case-sensitive. Nearest configured match: {nearestMatch}");
     }
@@ -74,12 +74,12 @@ class EndpointRegistry : IEndpointRegistry
             return address;
         }
 
-        var nearestMatch = GetNearestCaseInsensitiveMatch(endpointName, endpointAddressMappings.Keys);
+        var nearestMatch = GetClosestMatchForExceptionMessage(endpointName, endpointAddressMappings.Keys);
 
         throw new Exception($"No address mapping could be found for endpoint: {endpointName}. Ensure names have correct casing as mappings are case-sensitive. Nearest configured match: {nearestMatch}");
     }
 
-    static string GetNearestCaseInsensitiveMatch(string sourceEndpointName, IEnumerable<string> items)
+    static string GetClosestMatchForExceptionMessage(string sourceEndpointName, IEnumerable<string> items)
     {
         var calculator = new Levenshtein(sourceEndpointName.ToLower());
         var nearestMatch = items


### PR DESCRIPTION
GetNearestCaseInsensitiveMatch could throw when there are no mappings provided. Now returning `(No mappings registered)` when no mappings are provided.