### PR TITLE
Use Particular.Msmq package

### DIFF
--- a/src/AcceptanceTests.Msmq/AcceptanceTests.Msmq.csproj
+++ b/src/AcceptanceTests.Msmq/AcceptanceTests.Msmq.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
@@ -24,11 +24,5 @@
   <ItemGroup>
     <Compile Include="..\AcceptanceTests\Shared\**\*.cs" LinkBase="Shared" />
   </ItemGroup>
-
-  <!-- Workaround for "NETSDK1073: The FrameworkReference 'Microsoft.WindowsDesktop.App.WindowsForms' was not recognized" -->
-  <!-- This should not be required, but something is incorrectly causing the Microsoft.WindowsDesktop.App.WindowsForms reference -->
-  <PropertyGroup>
-    <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
-  </PropertyGroup>
 
 </Project>

--- a/src/AcceptanceTests.Msmq/ConfigureMsmqTransportTestExecution.cs
+++ b/src/AcceptanceTests.Msmq/ConfigureMsmqTransportTestExecution.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using MSMQ.Messaging;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
+using Particular.Msmq;
 
 class ConfigureMsmqTransportTestExecution : IConfigureTransportTestExecution
 {

--- a/src/NServiceBus.MessagingBridge.Msmq/MessagePump.cs
+++ b/src/NServiceBus.MessagingBridge.Msmq/MessagePump.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.MessagingBridge.Msmq
     using System.Threading;
     using System.Threading.Tasks;
     using Logging;
-    using MSMQ.Messaging;
+    using Particular.Msmq;
     using Support;
     using Transport;
 
@@ -172,7 +172,7 @@ namespace NServiceBus.MessagingBridge.Msmq
 
         async Task PumpMessages(CancellationToken messagePumpCancellationToken)
         {
-            using (var enumerator = inputQueue.GetMessageEnumerator2())
+            using (var enumerator = inputQueue.GetMessageEnumerator())
             {
                 while (true)
                 {

--- a/src/NServiceBus.MessagingBridge.Msmq/MessageQueueExtensions.cs
+++ b/src/NServiceBus.MessagingBridge.Msmq/MessageQueueExtensions.cs
@@ -4,7 +4,7 @@
     using System.ComponentModel;
     using System.Runtime.InteropServices;
     using System.Security.Principal;
-    using MSMQ.Messaging;
+    using Particular.Msmq;
 
     /// <summary>
     /// Reads the Access Control Entries (ACE) from an MSMQ queue.
@@ -34,11 +34,9 @@
         [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         static extern bool ConvertSidToStringSid([MarshalAs(UnmanagedType.LPArray)] byte[] pSID, out IntPtr ptrSid);
 
-        const string PREFIX_FORMAT_NAME = "FORMATNAME:";
         const int DACL_SECURITY_INFORMATION = 4;
         const int MQ_ERROR_SECURITY_DESCRIPTOR_TOO_SMALL = unchecked((int)0xc00e0023);
         const int MQ_OK = 0;
-        static bool administerGranted;
 
         //Security constants
 
@@ -75,14 +73,6 @@
 
         public static bool TryGetPermissions(this MessageQueue queue, string user, out MessageQueueAccessRights? rights, out AccessControlEntryType? accessType)
         {
-            if (!administerGranted)
-            {
-                var permission = new MessageQueuePermission(MessageQueuePermissionAccess.Administer, PREFIX_FORMAT_NAME + queue.FormatName);
-                permission.Demand();
-
-                administerGranted = true;
-            }
-
             var sid = GetSidForUser(user);
 
             try

--- a/src/NServiceBus.MessagingBridge.Msmq/MsmqBridgeTransport.cs
+++ b/src/NServiceBus.MessagingBridge.Msmq/MsmqBridgeTransport.cs
@@ -7,8 +7,8 @@ namespace NServiceBus
     using System.Threading.Tasks;
     using System.Transactions;
     using Features;
-    using MSMQ.Messaging;
     using NServiceBus.MessagingBridge.Msmq;
+    using Particular.Msmq;
     using Routing;
     using Transport;
 

--- a/src/NServiceBus.MessagingBridge.Msmq/MsmqMessageDispatcher.cs
+++ b/src/NServiceBus.MessagingBridge.Msmq/MsmqMessageDispatcher.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.MessagingBridge.Msmq
     using System.Threading;
     using System.Threading.Tasks;
     using System.Transactions;
-    using MSMQ.Messaging;
+    using Particular.Msmq;
     using Performance.TimeToBeReceived;
     using Transport;
     using Unicast.Queuing;

--- a/src/NServiceBus.MessagingBridge.Msmq/MsmqQueueCreator.cs
+++ b/src/NServiceBus.MessagingBridge.Msmq/MsmqQueueCreator.cs
@@ -1,9 +1,9 @@
 namespace NServiceBus.MessagingBridge.Msmq
 {
     using System.Collections.Generic;
-    using MSMQ.Messaging;
     using System.Security.Principal;
     using Logging;
+    using Particular.Msmq;
 
     class MsmqQueueCreator
     {

--- a/src/NServiceBus.MessagingBridge.Msmq/MsmqUtilities.cs
+++ b/src/NServiceBus.MessagingBridge.Msmq/MsmqUtilities.cs
@@ -4,10 +4,10 @@ namespace NServiceBus.MessagingBridge.Msmq
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using MSMQ.Messaging;
     using System.Text;
     using System.Xml;
     using Logging;
+    using Particular.Msmq;
     using Transport;
 
     class MsmqUtilities

--- a/src/NServiceBus.MessagingBridge.Msmq/NServiceBus.MessagingBridge.Msmq.csproj
+++ b/src/NServiceBus.MessagingBridge.Msmq/NServiceBus.MessagingBridge.Msmq.csproj
@@ -20,12 +20,6 @@
     <EmbeddedResource Include="InstanceMapping\Validators\endpoints.xsd" />
   </ItemGroup>
 
-  <!-- Workaround for "NETSDK1073: The FrameworkReference 'Microsoft.WindowsDesktop.App.WindowsForms' was not recognized" -->
-  <!-- This should not be required, but something is incorrectly causing the Microsoft.WindowsDesktop.App.WindowsForms reference -->
-  <PropertyGroup>
-    <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
-  </PropertyGroup>
-
   <ItemGroup>
     <InternalsVisibleTo Include="AcceptanceTests.Msmq" />
   </ItemGroup>

--- a/src/NServiceBus.MessagingBridge.Msmq/NServiceBus.MessagingBridge.Msmq.csproj
+++ b/src/NServiceBus.MessagingBridge.Msmq/NServiceBus.MessagingBridge.Msmq.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSMQ.Messaging" Version="1.0.4" />
     <PackageReference Include="NServiceBus" Version="9.0.0-alpha.6" />
+    <PackageReference Include="Particular.Msmq" Version="1.0.0-alpha.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,5 +25,9 @@
   <PropertyGroup>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="AcceptanceTests.Msmq" />
+  </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.MessagingBridge.Msmq/NoTransactionStrategy.cs
+++ b/src/NServiceBus.MessagingBridge.Msmq/NoTransactionStrategy.cs
@@ -2,10 +2,10 @@ namespace NServiceBus.MessagingBridge.Msmq
 {
     using System;
     using System.Buffers;
-    using MSMQ.Messaging;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
+    using Particular.Msmq;
     using Transport;
 
     class NoTransactionStrategy : ReceiveStrategy

--- a/src/NServiceBus.MessagingBridge.Msmq/QueuePermissions.cs
+++ b/src/NServiceBus.MessagingBridge.Msmq/QueuePermissions.cs
@@ -3,7 +3,7 @@
     using System.Security;
     using System.Security.Principal;
     using Logging;
-    using MSMQ.Messaging;
+    using Particular.Msmq;
 
     static class QueuePermissions
     {

--- a/src/NServiceBus.MessagingBridge.Msmq/ReceiveOnlyNativeTransactionStrategy.cs
+++ b/src/NServiceBus.MessagingBridge.Msmq/ReceiveOnlyNativeTransactionStrategy.cs
@@ -3,10 +3,10 @@
     using System;
     using System.Buffers;
     using System.Collections.Generic;
-    using MSMQ.Messaging;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
+    using Particular.Msmq;
     using Transport;
 
     class ReceiveOnlyNativeTransactionStrategy : ReceiveStrategy

--- a/src/NServiceBus.MessagingBridge.Msmq/ReceiveStrategy.cs
+++ b/src/NServiceBus.MessagingBridge.Msmq/ReceiveStrategy.cs
@@ -2,11 +2,11 @@ namespace NServiceBus.MessagingBridge.Msmq
 {
     using System;
     using System.Collections.Generic;
-    using MSMQ.Messaging;
     using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
     using Logging;
+    using Particular.Msmq;
     using Transport;
 
     abstract class ReceiveStrategy

--- a/src/NServiceBus.MessagingBridge.Msmq/SendsAtomicWithReceiveNativeTransactionStrategy.cs
+++ b/src/NServiceBus.MessagingBridge.Msmq/SendsAtomicWithReceiveNativeTransactionStrategy.cs
@@ -3,10 +3,10 @@ namespace NServiceBus.MessagingBridge.Msmq
     using System;
     using System.Buffers;
     using System.Collections.Generic;
-    using MSMQ.Messaging;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
+    using Particular.Msmq;
     using Transport;
 
     class SendsAtomicWithReceiveNativeTransactionStrategy : ReceiveStrategy

--- a/src/NServiceBus.MessagingBridge.Msmq/TransactionScopeStrategy.cs
+++ b/src/NServiceBus.MessagingBridge.Msmq/TransactionScopeStrategy.cs
@@ -3,11 +3,11 @@ namespace NServiceBus.MessagingBridge.Msmq
     using System;
     using System.Buffers;
     using System.Collections.Generic;
-    using MSMQ.Messaging;
     using System.Threading;
     using System.Threading.Tasks;
     using System.Transactions;
     using NServiceBus.Extensibility;
+    using Particular.Msmq;
     using Transport;
 
     class TransactionScopeStrategy : ReceiveStrategy


### PR DESCRIPTION
This PR changes the MSMQ bridge transport to use the new Particular.Msmq source package to access MSMQ from `net8.0-windows`.