### PR TITLE
MSMQ: Stop flooding logs in FailureRateCircuitBreaker

### DIFF
--- a/src/NServiceBus.MessagingBridge.Msmq/FailureRateCircuitBreaker.cs
+++ b/src/NServiceBus.MessagingBridge.Msmq/FailureRateCircuitBreaker.cs
@@ -17,13 +17,15 @@ namespace NServiceBus.MessagingBridge.Msmq
 
         public void Dispose()
         {
-            timer?.Dispose();
+            timer.Dispose();
         }
 
         void FlushHistory()
         {
-            Interlocked.Exchange(ref failureCount, 0);
-            Logger.InfoFormat("The circuit breaker for {0} is now disarmed", name);
+            if (Interlocked.Exchange(ref failureCount, 0) > 0)
+            {
+                Logger.InfoFormat("The circuit breaker for {0} is now disarmed", name);
+            }
         }
 
         public void Failure(Exception lastException)


### PR DESCRIPTION
The timer callback was previously reporting an INFO message every 30 seconds. Now only logged if the circuit breaker was previously set due to a failure.

Same logic that was fixed in the MSMQ transport:

- https://github.com/Particular/NServiceBus.Transport.Msmq/pull/630