### PR TITLE
Properly release all the circuit breaker associated timers

### DIFF
--- a/src/NServiceBus.MessagingBridge.Msmq/RepeatedFailuresOverTimeCircuitBreaker.cs
+++ b/src/NServiceBus.MessagingBridge.Msmq/RepeatedFailuresOverTimeCircuitBreaker.cs
@@ -43,10 +43,7 @@ namespace NServiceBus.MessagingBridge.Msmq
             return Task.Delay(TimeSpan.FromSeconds(1), CancellationToken.None);
         }
 
-        public void Dispose()
-        {
-            //Injected
-        }
+        public void Dispose() => timer.Dispose();
 
         void CircuitBreakerTriggered(object state)
         {


### PR DESCRIPTION
Timer wasn't properly disposed of. Rest of everything [is disposed here](https://github.com/Particular/NServiceBus.MessagingBridge/blob/master/src/NServiceBus.MessagingBridge.Msmq/MessagePump.cs#L138-L144).

Same logic that was fixed in the MSMQ transport:

- https://github.com/Particular/NServiceBus.Transport.Msmq/pull/632