### PR TITLE
Align ServiceControl queue name validation with UnicastAdressTag validations in NServiceBus

### DIFF
--- a/src/NServiceBus.MessagingBridge/Configuration/BridgeTransport.cs
+++ b/src/NServiceBus.MessagingBridge/Configuration/BridgeTransport.cs
@@ -85,6 +85,11 @@ public class BridgeTransport
     /// <param name="timeToLive">The maximum time to live for the heartbeat.</param>
     public void SendHeartbeatTo(string serviceControlQueue, TimeSpan? frequency = null, TimeSpan? timeToLive = null)
     {
+        if (string.IsNullOrWhiteSpace(serviceControlQueue))
+        {
+            throw new ArgumentException(serviceControlQueue);
+        }
+
         var freq = frequency ?? TimeSpan.FromSeconds(10);
         var ttl = timeToLive ?? TimeSpan.FromTicks(freq.Ticks * 4);
         Heartbeats.ServiceControlQueue = serviceControlQueue;
@@ -99,7 +104,12 @@ public class BridgeTransport
     /// <param name="timeToLive">The maximum time to live for the custom check report messages. Defaults to 4 times the check interval.</param>
     public void ReportCustomChecksTo(string serviceControlQueue, TimeSpan? timeToLive = null)
     {
-        CustomChecks.ServiceControlQueue ??= serviceControlQueue ?? throw new ArgumentException(serviceControlQueue);
+        if (string.IsNullOrWhiteSpace(serviceControlQueue))
+        {
+            throw new ArgumentException(serviceControlQueue);
+        }
+
+        CustomChecks.ServiceControlQueue = serviceControlQueue;
 
         CustomChecks.TimeToLive = timeToLive;
     }

--- a/src/NServiceBus.MessagingBridge/Configuration/BridgeTransport.cs
+++ b/src/NServiceBus.MessagingBridge/Configuration/BridgeTransport.cs
@@ -85,10 +85,7 @@ public class BridgeTransport
     /// <param name="timeToLive">The maximum time to live for the heartbeat.</param>
     public void SendHeartbeatTo(string serviceControlQueue, TimeSpan? frequency = null, TimeSpan? timeToLive = null)
     {
-        if (string.IsNullOrWhiteSpace(serviceControlQueue))
-        {
-            throw new ArgumentException(serviceControlQueue);
-        }
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceControlQueue);
 
         var freq = frequency ?? TimeSpan.FromSeconds(10);
         var ttl = timeToLive ?? TimeSpan.FromTicks(freq.Ticks * 4);
@@ -104,13 +101,9 @@ public class BridgeTransport
     /// <param name="timeToLive">The maximum time to live for the custom check report messages. Defaults to 4 times the check interval.</param>
     public void ReportCustomChecksTo(string serviceControlQueue, TimeSpan? timeToLive = null)
     {
-        if (string.IsNullOrWhiteSpace(serviceControlQueue))
-        {
-            throw new ArgumentException(serviceControlQueue);
-        }
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceControlQueue);
 
         CustomChecks.ServiceControlQueue = serviceControlQueue;
-
         CustomChecks.TimeToLive = timeToLive;
     }
 

--- a/src/NServiceBus.MessagingBridge/CustomChecks/CustomChecksBackgroundService.cs
+++ b/src/NServiceBus.MessagingBridge/CustomChecks/CustomChecksBackgroundService.cs
@@ -50,7 +50,7 @@ class CustomChecksBackgroundService
 
         foreach (var bridgeTransportConfiguration in bridgeConfiguration.TransportConfigurations)
         {
-            if (bridgeTransportConfiguration.CustomChecks != null)
+            if (bridgeTransportConfiguration.CustomChecks.ServiceControlQueue != null)
             {
                 var sendOnlyMessageDispatcher =
                     await CreateSendOnlyMessageDispatcher(bridgeTransportConfiguration, stoppingToken)


### PR DESCRIPTION
This change aligns validation done in the Messaging Bridge configuration API with [the validation done by `UnicastAddressTag`](https://github.com/Particular/NServiceBus/blob/release-8.1/src/NServiceBus.Core/Routing/UnicastAddressTag.cs#L14) used when custom checks and heartbeat are sent by the Bridge to ServiceControl queue.