### PR TITLE
Align ServiceControl queue name validation with UnicastAdressTag validations in NServiceBus

### DIFF
--- a/src/NServiceBus.MessagingBridge/Configuration/BridgeTransport.cs
+++ b/src/NServiceBus.MessagingBridge/Configuration/BridgeTransport.cs
@@ -101,7 +101,7 @@
         {
             if (string.IsNullOrWhiteSpace(serviceControlQueue))
             {
-                throw new ArgumentException($"{serviceControlQueue} cannot be null or whitespace");
+                throw new ArgumentNullException(nameof(serviceControlQueue));
             }
 
             CustomChecks.ServiceControlQueue = serviceControlQueue;

--- a/src/NServiceBus.MessagingBridge/Configuration/BridgeTransport.cs
+++ b/src/NServiceBus.MessagingBridge/Configuration/BridgeTransport.cs
@@ -99,10 +99,12 @@
         /// <param name="timeToLive">The maximum time to live for the custom check report messages. Defaults to 4 times the check interval.</param>
         public void ReportCustomChecksTo(string serviceControlQueue, TimeSpan? timeToLive = null)
         {
-            CustomChecks.ServiceControlQueue =
-                CustomChecks.ServiceControlQueue
-                ?? serviceControlQueue
-                ?? throw new ArgumentException(serviceControlQueue);
+            if (string.IsNullOrWhiteSpace(serviceControlQueue))
+            {
+                throw new ArgumentException($"{serviceControlQueue} cannot be null or whitespace");
+            }
+
+            CustomChecks.ServiceControlQueue = serviceControlQueue;
 
             CustomChecks.TimeToLive = timeToLive;
         }

--- a/src/NServiceBus.MessagingBridge/CustomChecks/CustomChecksBackgroundService.cs
+++ b/src/NServiceBus.MessagingBridge/CustomChecks/CustomChecksBackgroundService.cs
@@ -50,7 +50,7 @@
 
             foreach (var bridgeTransportConfiguration in bridgeConfiguration.TransportConfigurations)
             {
-                if (bridgeTransportConfiguration.CustomChecks != null)
+                if (bridgeTransportConfiguration.CustomChecks.ServiceControlQueue != null)
                 {
                     var sendOnlyMessageDispatcher =
                         await CreateSendOnlyMessageDispatcher(bridgeTransportConfiguration, stoppingToken)


### PR DESCRIPTION
This change aligns validation done in the Messaging Bridge configuration API with the validation done by UnicastAddressTag used when custom checks and heartbeat are sent by the Bridge to ServiceControl queue.