### PR TITLE
Update to NServiceBus.Transport.Msmq.Sources 3.0.1 to avoid emitting a BOM in the message headers

### DIFF
--- a/src/NServiceBus.MessagingBridge.Msmq/NServiceBus.MessagingBridge.Msmq.csproj
+++ b/src/NServiceBus.MessagingBridge.Msmq/NServiceBus.MessagingBridge.Msmq.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[9.0.0, 10.0.0)" />
-    <PackageReference Include="NServiceBus.Transport.Msmq.Sources" Version="3.0.0" PrivateAssets="All" />
+    <PackageReference Include="NServiceBus.Transport.Msmq.Sources" Version="3.0.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
See https://github.com/Particular/NServiceBus.Transport.Msmq/pull/711 for more details