### PR TITLE
Bridged messages can't be handled by older MSMQ endpoints

### DIFF
--- a/src/NServiceBus.MessagingBridge.Msmq/NServiceBus.MessagingBridge.Msmq.csproj
+++ b/src/NServiceBus.MessagingBridge.Msmq/NServiceBus.MessagingBridge.Msmq.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[9.0.0, 10.0.0)" />
-    <PackageReference Include="NServiceBus.Transport.Msmq.Sources" Version="3.0.0" PrivateAssets="All" />
+    <PackageReference Include="NServiceBus.Transport.Msmq.Sources" Version="3.0.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Backport of https://github.com/Particular/NServiceBus.MessagingBridge/pull/455 to v3.0