### PR TITLE
Bridge can't transfer messages that have the ReplyToAddress equal to the proxy queue name

### DIFF
--- a/src/AcceptanceTests/Shared/Send_local.cs
+++ b/src/AcceptanceTests/Shared/Send_local.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.Features;
+using NUnit.Framework;
+using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
+
+public class Send_local : BridgeAcceptanceTest
+{
+    static string OriginalEndpointName = Conventions.EndpointNamingConvention(typeof(OriginalEndpoint));
+
+    [Test]
+    public async Task Should_transfer_send_local_message()
+    {
+        var ctx = await Scenario.Define<Context>()
+                    .WithEndpoint<OriginalEndpoint>()
+                    .WithEndpoint<MigratedEndpoint>()
+                    .WithBridge(bridgeConfiguration =>
+                    {
+                        var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
+                        bridgeTransport.HasEndpoint("_");
+                        bridgeConfiguration.AddTransport(bridgeTransport);
+
+                        bridgeConfiguration.AddTestTransportEndpoint(new BridgeEndpoint(OriginalEndpointName));
+                    })
+                    .Done(c => c.MessageReceived)
+                    .Run();
+
+        Assert.IsTrue(ctx.MessageReceived);
+    }
+
+    public class Context : ScenarioContext
+    {
+        public bool MessageReceived { get; set; }
+    }
+
+    public class MigratedEndpoint : EndpointConfigurationBuilder
+    {
+        public MigratedEndpoint()
+        {
+            CustomEndpointName(OriginalEndpointName);
+            EndpointSetup<DefaultTestServer>();
+        }
+
+        public class AMessageHandler : IHandleMessages<AMessage>
+        {
+            public AMessageHandler(Context context)
+            {
+                testContext = context;
+            }
+
+            public Task Handle(AMessage message, IMessageHandlerContext context)
+            {
+                testContext.MessageReceived = true;
+                return Task.CompletedTask;
+            }
+
+            Context testContext;
+        }
+    }
+
+    public class OriginalEndpoint : EndpointConfigurationBuilder
+    {
+        public OriginalEndpoint() => EndpointSetup<DefaultServer>();
+
+        public class SendLocalFeature : Feature
+        {
+            public SendLocalFeature() => EnableByDefault();
+
+            protected override void Setup(FeatureConfigurationContext context) => context.RegisterStartupTask(() => new SendLocalStartupTask());
+
+            class SendLocalStartupTask : FeatureStartupTask
+            {
+                protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
+                {
+                    await session.SendLocal(new AMessage(), cancellationToken);
+
+                    await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+                }
+
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.FromResult(0);
+            }
+        }
+    }
+
+    public class AMessage : IMessage
+    {
+    }
+}

--- a/src/NServiceBus.MessagingBridge/MessageShovel.cs
+++ b/src/NServiceBus.MessagingBridge/MessageShovel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -55,7 +55,7 @@ sealed class MessageShovel : IMessageShovel
                 // This is a regular message sent between the endpoints on different sides of the bridge.
                 // The ReplyToAddress is transformed to allow for replies to be delivered
                 messageToSend.Headers[BridgeHeaders.Transfer] = transferDetails;
-                TransformAddressHeader(messageToSend, targetEndpointRegistry, Headers.ReplyToAddress);
+                TransformRegularMessageReplyToAddress(transferContext, messageToSend, targetEndpointRegistry);
             }
 
             await targetEndpointDispatcher.Dispatch(
@@ -81,6 +81,28 @@ sealed class MessageShovel : IMessageShovel
     static bool IsErrorMessage(OutgoingMessage messageToSend) => messageToSend.Headers.ContainsKey(FaultsHeaderKeys.FailedQ);
 
     static bool IsRetryMessage(OutgoingMessage messageToSend) => messageToSend.Headers.ContainsKey("ServiceControl.Retry.UniqueMessageId");
+
+    static void TransformRegularMessageReplyToAddress(
+        TransferContext transferContext,
+        OutgoingMessage messageToSend,
+        IEndpointRegistry targetEndpointRegistry)
+    {
+        if (!messageToSend.Headers.TryGetValue(Headers.ReplyToAddress, out var headerValue))
+        {
+            return;
+        }
+
+        //If the bridge is transferring a message that was sent by an endpoint to itself e.g. via SendLocal,
+        //then the ReplyToAddress value should be transformed to physical address of the source endpoint on the target side
+        if (headerValue == transferContext.MessageToTransfer.ReceiveAddress)
+        {
+            messageToSend.Headers[Headers.ReplyToAddress] = targetEndpointRegistry.GetEndpointAddress(transferContext.SourceEndpointName);
+        }
+        else
+        {
+            messageToSend.Headers[Headers.ReplyToAddress] = targetEndpointRegistry.TranslateToTargetAddress(headerValue);
+        }
+    }
 
     void TransformAddressHeader(
         OutgoingMessage messageToSend,


### PR DESCRIPTION
Backport of #475 which fixes #bridge can #474 for the `release-2.2` branch