### PR TITLE
Bridge does not translate the `ReplyToAddress` for failed messages and retries 

### DIFF
--- a/src/AcceptanceTests/Shared/Retry.cs
+++ b/src/AcceptanceTests/Shared/Retry.cs
@@ -49,8 +49,8 @@ public class Retry : BridgeAcceptanceTest
             {
                 if (header.Key == Headers.ReplyToAddress)
                 {
-                    Assert.IsTrue(receivedHeaderValue.Contains(header.Value),
-                        $"The ReplyToAddress received by ServiceControl (learning transport physical address) should be contained in the {TestTransport} physical address.");
+                    Assert.IsTrue(receivedHeaderValue.ToLower().Contains(nameof(ProcessingEndpoint).ToLower()),
+                        $"The ReplyToAddress received by ServiceControl ({TransportBeingTested} physical address) should contain the logical name of the endpoint.");
                 }
                 else
                 {

--- a/src/AcceptanceTests/Shared/Retry.cs
+++ b/src/AcceptanceTests/Shared/Retry.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting;
-using NServiceBus.AcceptanceTesting.Customization;
 using NServiceBus.Faults;
+using NServiceBus.Logging;
 using NServiceBus.Pipeline;
 using NUnit.Framework;
 using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
@@ -22,7 +23,6 @@ public class Retry : BridgeAcceptanceTest
                 builder.When(c => c.EndpointsStarted, (session, _) => session.SendLocal(new FaultyMessage()));
             })
             .WithEndpoint<FakeSCError>()
-            .WithEndpoint<FakeSCAudit>()
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(DefaultTestServer.GetTestTransportDefinition())
@@ -30,32 +30,90 @@ public class Retry : BridgeAcceptanceTest
                     Name = "DefaultTestingTransport"
                 };
                 bridgeTransport.AddTestEndpoint<FakeSCError>();
-                bridgeTransport.AddTestEndpoint<FakeSCAudit>();
                 bridgeConfiguration.AddTransport(bridgeTransport);
 
-                var processingEndpoint =
-                    new BridgeEndpoint(Conventions.EndpointNamingConvention(typeof(ProcessingEndpoint)));
-
                 var theOtherTransport = new TestableBridgeTransport(TransportBeingTested);
-                theOtherTransport.HasEndpoint(processingEndpoint);
+                theOtherTransport.AddTestEndpoint<ProcessingEndpoint>();
                 bridgeConfiguration.AddTransport(theOtherTransport);
             })
-            .Done(c => c.GotRetrySuccessfullAck && c.MessageAudited)
+            .Done(c => c.GotRetrySuccessfullAck)
             .Run();
 
         Assert.IsTrue(ctx.MessageFailed);
         Assert.IsTrue(ctx.RetryDelivered);
         Assert.IsTrue(ctx.GotRetrySuccessfullAck);
-        Assert.IsTrue(ctx.MessageAudited);
 
         foreach (var header in ctx.FailedMessageHeaders)
         {
             if (ctx.ReceivedMessageHeaders.TryGetValue(header.Key, out var receivedHeaderValue))
             {
-                Assert.AreEqual(header.Value, receivedHeaderValue,
-                    $"{header.Key} is not the same on processed message and message sent to the error queue");
+                if (header.Key == Headers.ReplyToAddress)
+                {
+                    Assert.IsTrue(receivedHeaderValue.Contains(header.Value),
+                        $"The ReplyToAddress received by ServiceControl (learning transport physical address) should be contained in the {TestTransport} physical address.");
+                }
+                else
+                {
+                    Assert.AreEqual(header.Value, receivedHeaderValue,
+                        $"{header.Key} is not the same on processed message and message sent to the error queue");
+                }
             }
         }
+    }
+
+    [Test]
+    public async Task Should_log_warn_when_best_effort_ReplyToAddress_fails()
+    {
+        var ctx = await Scenario.Define<Context>()
+            .WithEndpoint<SendingEndpoint>(builder =>
+            {
+                builder.DoNotFailOnErrorMessages();
+                builder.When(c => c.EndpointsStarted, (session, _) => session.Send(new FaultyMessage()));
+            })
+            .WithEndpoint<ProcessingEndpoint>(builder =>
+            {
+                builder.DoNotFailOnErrorMessages();
+                builder.When(c => c.EndpointsStarted, (session, _) =>
+                {
+                    var options = new SendOptions();
+                    options.RouteToThisEndpoint();
+                    options.SetHeader(Headers.ReplyToAddress, "address-not-declared-in-the-bridge");
+                    return session.Send(new FaultyMessage(), options);
+                });
+            })
+            .WithEndpoint<FakeSCError>()
+            .WithBridge(bridgeConfiguration =>
+            {
+                var bridgeTransport = new TestableBridgeTransport(DefaultTestServer.GetTestTransportDefinition())
+                {
+                    Name = "DefaultTestingTransport"
+                };
+                bridgeTransport.AddTestEndpoint<FakeSCError>();
+                bridgeConfiguration.AddTransport(bridgeTransport);
+
+                var theOtherTransport = new TestableBridgeTransport(TransportBeingTested);
+                theOtherTransport.AddTestEndpoint<ProcessingEndpoint>();
+                bridgeConfiguration.AddTransport(theOtherTransport);
+            })
+            .Done(c => c.GotRetrySuccessfullAck)
+            .Run();
+
+        var translationFailureLogs = ctx.Logs.ToArray().Where(i =>
+            i.Message.Contains("Could not translate") &&
+            i.Message.Contains("address. Consider using `.HasEndpoint()`"));
+
+        //There is only one warning here because the ServiceControl testing fake does not properly set the ReplyToAddress header value
+        Assert.AreEqual(1, translationFailureLogs.Count(),
+            "Bridge should log warnings when ReplyToAddress cannot be translated for failed message and retry.");
+    }
+
+    public class SendingEndpoint : EndpointConfigurationBuilder
+    {
+        public SendingEndpoint() => EndpointSetup<DefaultServer>(c =>
+        {
+            c.SendFailedMessagesTo(Conventions.EndpointNamingConvention(typeof(FakeSCError)));
+            c.ConfigureRouting().RouteToEndpoint(typeof(FaultyMessage), Conventions.EndpointNamingConvention(typeof(ProcessingEndpoint)));
+        });
     }
 
     public class ProcessingEndpoint : EndpointConfigurationBuilder
@@ -63,7 +121,6 @@ public class Retry : BridgeAcceptanceTest
         public ProcessingEndpoint() => EndpointSetup<DefaultServer>(c =>
         {
             c.SendFailedMessagesTo(Conventions.EndpointNamingConvention(typeof(FakeSCError)));
-            c.AuditProcessedMessagesTo(Conventions.EndpointNamingConvention(typeof(FakeSCAudit)));
         });
 
         public class MessageHandler : IHandleMessages<FaultyMessage>
@@ -138,35 +195,13 @@ public class Retry : BridgeAcceptanceTest
         }
     }
 
-    public class FakeSCAudit : EndpointConfigurationBuilder
-    {
-        public FakeSCAudit() => EndpointSetup<DefaultTestServer>();
-
-        class FailedMessageHander : IHandleMessages<FaultyMessage>
-        {
-            public FailedMessageHander(Context context) => testContext = context;
-
-            public Task Handle(FaultyMessage message, IMessageHandlerContext context)
-            {
-                testContext.MessageAudited = true;
-
-                return Task.CompletedTask;
-            }
-
-            readonly Context testContext;
-        }
-    }
-
     public class Context : ScenarioContext
     {
-        public bool SubscriberSubscribed { get; set; }
         public bool MessageFailed { get; set; }
         public IReadOnlyDictionary<string, string> ReceivedMessageHeaders { get; set; }
         public IReadOnlyDictionary<string, string> FailedMessageHeaders { get; set; }
-        public IReadOnlyDictionary<string, string> AuditMessageHeaders { get; set; }
         public bool RetryDelivered { get; set; }
         public bool GotRetrySuccessfullAck { get; set; }
-        public bool MessageAudited { get; set; }
     }
 
     public class FaultyMessage : IMessage

--- a/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
+++ b/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
@@ -1,15 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 using NServiceBus;
 using NServiceBus.Raw;
 using NServiceBus.Transport;
 
 class EndpointRegistry : IEndpointRegistry
 {
-    public EndpointRegistry(ILogger<EndpointRegistry> logger) => this.logger = logger;
-
     public void RegisterDispatcher(
         BridgeEndpoint endpoint,
         string targetTransportName,
@@ -58,17 +55,14 @@ class EndpointRegistry : IEndpointRegistry
         throw new Exception($"No target endpoint dispatcher could be found for endpoint: {sourceEndpointName}. Ensure names have correct casing as mappings are case-sensitive. Nearest configured match: {nearestMatch}");
     }
 
-    public bool TryTranslateToTargetAddress(string sourceAddress, out (string targetAddress, string nearestMatch) result)
+    public bool TryTranslateToTargetAddress(string sourceAddress, out string bestMatch)
     {
-        if (targetEndpointAddressMappings.TryGetValue(sourceAddress, out result.targetAddress))
+        if (targetEndpointAddressMappings.TryGetValue(sourceAddress, out bestMatch))
         {
-            result.nearestMatch = result.targetAddress;
             return true;
         }
 
-        logger.LogWarning($"Could not translate {sourceAddress} address. Consider using `.HasEndpoint()` method to add missing endpoint declaration.");
-
-        result.nearestMatch = GetClosestMatchForExceptionMessage(sourceAddress, targetEndpointAddressMappings.Keys);
+        bestMatch = GetClosestMatchForExceptionMessage(sourceAddress, targetEndpointAddressMappings.Keys);
         return false;
     }
 

--- a/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
+++ b/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
@@ -1,12 +1,15 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using NServiceBus;
 using NServiceBus.Raw;
 using NServiceBus.Transport;
 
 class EndpointRegistry : IEndpointRegistry
 {
+    public EndpointRegistry(ILogger<EndpointRegistry> logger) => this.logger = logger;
+
     public void RegisterDispatcher(
         BridgeEndpoint endpoint,
         string targetTransportName,
@@ -55,16 +58,18 @@ class EndpointRegistry : IEndpointRegistry
         throw new Exception($"No target endpoint dispatcher could be found for endpoint: {sourceEndpointName}. Ensure names have correct casing as mappings are case-sensitive. Nearest configured match: {nearestMatch}");
     }
 
-    public string TranslateToTargetAddress(string sourceAddress)
+    public bool TryTranslateToTargetAddress(string sourceAddress, out (string targetAddress, string nearestMatch) result)
     {
-        if (targetEndpointAddressMappings.TryGetValue(sourceAddress, out var targetAddress))
+        if (targetEndpointAddressMappings.TryGetValue(sourceAddress, out result.targetAddress))
         {
-            return targetAddress;
+            result.nearestMatch = result.targetAddress;
+            return true;
         }
 
-        var nearestMatch = GetClosestMatchForExceptionMessage(sourceAddress, targetEndpointAddressMappings.Keys);
+        logger.LogWarning($"Could not translate {sourceAddress} address. Consider using `.HasEndpoint()` method to add missing endpoint declaration.");
 
-        throw new Exception($"No target address mapping could be found for source address: {sourceAddress}. Ensure names have correct casing as mappings are case-sensitive. Nearest configured match: {nearestMatch}");
+        result.nearestMatch = GetClosestMatchForExceptionMessage(sourceAddress, targetEndpointAddressMappings.Keys);
+        return false;
     }
 
     public string GetEndpointAddress(string endpointName)

--- a/src/NServiceBus.MessagingBridge/IEndpointRegistry.cs
+++ b/src/NServiceBus.MessagingBridge/IEndpointRegistry.cs
@@ -2,7 +2,7 @@
 {
     TargetEndpointDispatcher GetTargetEndpointDispatcher(string sourceEndpointName);
 
-    string TranslateToTargetAddress(string sourceAddress);
+    bool TryTranslateToTargetAddress(string sourceAddress, out (string targetAddress, string nearestMatch) result);
 
     string GetEndpointAddress(string endpointName);
 }

--- a/src/NServiceBus.MessagingBridge/IEndpointRegistry.cs
+++ b/src/NServiceBus.MessagingBridge/IEndpointRegistry.cs
@@ -2,7 +2,7 @@
 {
     TargetEndpointDispatcher GetTargetEndpointDispatcher(string sourceEndpointName);
 
-    bool TryTranslateToTargetAddress(string sourceAddress, out (string targetAddress, string nearestMatch) result);
+    bool TryTranslateToTargetAddress(string sourceAddress, out string bestMatch);
 
     string GetEndpointAddress(string endpointName);
 }

--- a/src/UnitTests/MessageShovelTests.cs
+++ b/src/UnitTests/MessageShovelTests.cs
@@ -194,11 +194,11 @@ public class MessageShovelTests
             return new TargetEndpointDispatcher(targetTransport, rawEndpoint, targetEndpoint.QueueAddress);
         }
 
-        public bool TryTranslateToTargetAddress(string sourceAddress, out (string targetAddress, string nearestMatch) translation)
+        public bool TryTranslateToTargetAddress(string sourceAddress, out string bestMatch)
         {
             var result = sourceAddress.Split('@').First();
 
-            translation.nearestMatch = translation.targetAddress = result;
+            bestMatch = result;
             return true;
         }
 

--- a/src/UnitTests/MessageShovelTests.cs
+++ b/src/UnitTests/MessageShovelTests.cs
@@ -194,9 +194,12 @@ public class MessageShovelTests
             return new TargetEndpointDispatcher(targetTransport, rawEndpoint, targetEndpoint.QueueAddress);
         }
 
-        public string TranslateToTargetAddress(string sourceAddress)
+        public bool TryTranslateToTargetAddress(string sourceAddress, out (string targetAddress, string nearestMatch) translation)
         {
-            return sourceAddress.Split('@').First();
+            var result = sourceAddress.Split('@').First();
+
+            translation.nearestMatch = translation.targetAddress = result;
+            return true;
         }
 
         public string GetEndpointAddress(string endpointName) => throw new NotImplementedException();


### PR DESCRIPTION
Backport of #481 which fixes #480 for the `release-2.2` branch