### PR TITLE
Bridge does not translate the `ReplyToAddress` for failed messages and retries 

### DIFF
--- a/src/AcceptanceTests/Shared/Retry.cs
+++ b/src/AcceptanceTests/Shared/Retry.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting;
-using NServiceBus.AcceptanceTesting.Customization;
 using NServiceBus.Faults;
+using NServiceBus.Logging;
 using NServiceBus.Pipeline;
 using NUnit.Framework;
 using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
@@ -22,7 +23,6 @@ public class Retry : BridgeAcceptanceTest
                 builder.When(c => c.EndpointsStarted, (session, _) => session.SendLocal(new FaultyMessage()));
             })
             .WithEndpoint<FakeSCError>()
-            .WithEndpoint<FakeSCAudit>()
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(DefaultTestServer.GetTestTransportDefinition())
@@ -30,32 +30,90 @@ public class Retry : BridgeAcceptanceTest
                     Name = "DefaultTestingTransport"
                 };
                 bridgeTransport.AddTestEndpoint<FakeSCError>();
-                bridgeTransport.AddTestEndpoint<FakeSCAudit>();
                 bridgeConfiguration.AddTransport(bridgeTransport);
 
-                var processingEndpoint =
-                    new BridgeEndpoint(Conventions.EndpointNamingConvention(typeof(ProcessingEndpoint)));
-
                 var theOtherTransport = new TestableBridgeTransport(TransportBeingTested);
-                theOtherTransport.HasEndpoint(processingEndpoint);
+                theOtherTransport.AddTestEndpoint<ProcessingEndpoint>();
                 bridgeConfiguration.AddTransport(theOtherTransport);
             })
-            .Done(c => c.GotRetrySuccessfullAck && c.MessageAudited)
+            .Done(c => c.GotRetrySuccessfullAck)
             .Run();
 
         Assert.IsTrue(ctx.MessageFailed);
         Assert.IsTrue(ctx.RetryDelivered);
         Assert.IsTrue(ctx.GotRetrySuccessfullAck);
-        Assert.IsTrue(ctx.MessageAudited);
 
         foreach (var header in ctx.FailedMessageHeaders)
         {
             if (ctx.ReceivedMessageHeaders.TryGetValue(header.Key, out var receivedHeaderValue))
             {
-                Assert.AreEqual(header.Value, receivedHeaderValue,
-                    $"{header.Key} is not the same on processed message and message sent to the error queue");
+                if (header.Key == Headers.ReplyToAddress)
+                {
+                    Assert.IsTrue(receivedHeaderValue.Contains(header.Value),
+                        $"The ReplyToAddress received by ServiceControl (learning transport physical address) should be contained in the {TestTransport} physical address.");
+                }
+                else
+                {
+                    Assert.AreEqual(header.Value, receivedHeaderValue,
+                        $"{header.Key} is not the same on processed message and message sent to the error queue");
+                }
             }
         }
+    }
+
+    [Test]
+    public async Task Should_log_warn_when_best_effort_ReplyToAddress_fails()
+    {
+        var ctx = await Scenario.Define<Context>()
+            .WithEndpoint<SendingEndpoint>(builder =>
+            {
+                builder.DoNotFailOnErrorMessages();
+                builder.When(c => c.EndpointsStarted, (session, _) => session.Send(new FaultyMessage()));
+            })
+            .WithEndpoint<ProcessingEndpoint>(builder =>
+            {
+                builder.DoNotFailOnErrorMessages();
+                builder.When(c => c.EndpointsStarted, (session, _) =>
+                {
+                    var options = new SendOptions();
+                    options.RouteToThisEndpoint();
+                    options.SetHeader(Headers.ReplyToAddress, "address-not-declared-in-the-bridge");
+                    return session.Send(new FaultyMessage(), options);
+                });
+            })
+            .WithEndpoint<FakeSCError>()
+            .WithBridge(bridgeConfiguration =>
+            {
+                var bridgeTransport = new TestableBridgeTransport(DefaultTestServer.GetTestTransportDefinition())
+                {
+                    Name = "DefaultTestingTransport"
+                };
+                bridgeTransport.AddTestEndpoint<FakeSCError>();
+                bridgeConfiguration.AddTransport(bridgeTransport);
+
+                var theOtherTransport = new TestableBridgeTransport(TransportBeingTested);
+                theOtherTransport.AddTestEndpoint<ProcessingEndpoint>();
+                bridgeConfiguration.AddTransport(theOtherTransport);
+            })
+            .Done(c => c.GotRetrySuccessfullAck)
+            .Run();
+
+        var translationFailureLogs = ctx.Logs.ToArray().Where(i =>
+            i.Message.Contains("Could not translate") &&
+            i.Message.Contains("address. Consider using `.HasEndpoint()`"));
+
+        //There is only one warning here because the ServiceControl testing fake does not properly set the ReplyToAddress header value
+        Assert.AreEqual(1, translationFailureLogs.Count(),
+            "Bridge should log warnings when ReplyToAddress cannot be translated for failed message and retry.");
+    }
+
+    public class SendingEndpoint : EndpointConfigurationBuilder
+    {
+        public SendingEndpoint() => EndpointSetup<DefaultServer>(c =>
+        {
+            c.SendFailedMessagesTo(Conventions.EndpointNamingConvention(typeof(FakeSCError)));
+            c.ConfigureRouting().RouteToEndpoint(typeof(FaultyMessage), Conventions.EndpointNamingConvention(typeof(ProcessingEndpoint)));
+        });
     }
 
     public class ProcessingEndpoint : EndpointConfigurationBuilder
@@ -63,7 +121,6 @@ public class Retry : BridgeAcceptanceTest
         public ProcessingEndpoint() => EndpointSetup<DefaultServer>(c =>
         {
             c.SendFailedMessagesTo(Conventions.EndpointNamingConvention(typeof(FakeSCError)));
-            c.AuditProcessedMessagesTo(Conventions.EndpointNamingConvention(typeof(FakeSCAudit)));
         });
 
         public class MessageHandler : IHandleMessages<FaultyMessage>
@@ -138,35 +195,13 @@ public class Retry : BridgeAcceptanceTest
         }
     }
 
-    public class FakeSCAudit : EndpointConfigurationBuilder
-    {
-        public FakeSCAudit() => EndpointSetup<DefaultTestServer>();
-
-        class FailedMessageHander : IHandleMessages<FaultyMessage>
-        {
-            public FailedMessageHander(Context context) => testContext = context;
-
-            public Task Handle(FaultyMessage message, IMessageHandlerContext context)
-            {
-                testContext.MessageAudited = true;
-
-                return Task.CompletedTask;
-            }
-
-            readonly Context testContext;
-        }
-    }
-
     public class Context : ScenarioContext
     {
-        public bool SubscriberSubscribed { get; set; }
         public bool MessageFailed { get; set; }
         public IReadOnlyDictionary<string, string> ReceivedMessageHeaders { get; set; }
         public IReadOnlyDictionary<string, string> FailedMessageHeaders { get; set; }
-        public IReadOnlyDictionary<string, string> AuditMessageHeaders { get; set; }
         public bool RetryDelivered { get; set; }
         public bool GotRetrySuccessfullAck { get; set; }
-        public bool MessageAudited { get; set; }
     }
 
     public class FaultyMessage : IMessage

--- a/src/AcceptanceTests/Shared/Retry.cs
+++ b/src/AcceptanceTests/Shared/Retry.cs
@@ -49,8 +49,8 @@ public class Retry : BridgeAcceptanceTest
             {
                 if (header.Key == Headers.ReplyToAddress)
                 {
-                    Assert.IsTrue(receivedHeaderValue.Contains(header.Value),
-                        $"The ReplyToAddress received by ServiceControl (learning transport physical address) should be contained in the {TestTransport} physical address.");
+                    Assert.IsTrue(receivedHeaderValue.Contains(nameof(ProcessingEndpoint), StringComparison.InvariantCultureIgnoreCase),
+                        $"The ReplyToAddress received by ServiceControl ({TransportBeingTested} physical address) should contain the logical name of the endpoint.");
                 }
                 else
                 {

--- a/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
+++ b/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
@@ -1,15 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 using NServiceBus;
 using NServiceBus.Raw;
 using NServiceBus.Transport;
 
 class EndpointRegistry : IEndpointRegistry
 {
-    public EndpointRegistry(ILogger<EndpointRegistry> logger) => this.logger = logger;
-
     public void RegisterDispatcher(
         BridgeEndpoint endpoint,
         string targetTransportName,
@@ -63,17 +60,14 @@ class EndpointRegistry : IEndpointRegistry
         throw new Exception($"No target endpoint dispatcher could be found for endpoint: {sourceEndpointName}. Ensure names have correct casing as mappings are case-sensitive. Nearest configured match: {nearestMatch}");
     }
 
-    public bool TryTranslateToTargetAddress(string sourceAddress, out (string targetAddress, string nearestMatch) result)
+    public bool TryTranslateToTargetAddress(string sourceAddress, out string bestMatch)
     {
-        if (targetEndpointAddressMappings.TryGetValue(sourceAddress, out result.targetAddress))
+        if (targetEndpointAddressMappings.TryGetValue(sourceAddress, out bestMatch))
         {
-            result.nearestMatch = result.targetAddress;
             return true;
         }
 
-        logger.LogWarning($"Could not translate {sourceAddress} address. Consider using `.HasEndpoint()` method to add missing endpoint declaration.");
-
-        result.nearestMatch = GetClosestMatchForExceptionMessage(sourceAddress, targetEndpointAddressMappings.Keys);
+        bestMatch = GetClosestMatchForExceptionMessage(sourceAddress, targetEndpointAddressMappings.Keys);
         return false;
     }
 

--- a/src/NServiceBus.MessagingBridge/IEndpointRegistry.cs
+++ b/src/NServiceBus.MessagingBridge/IEndpointRegistry.cs
@@ -2,7 +2,7 @@
 {
     TargetEndpointDispatcher GetTargetEndpointDispatcher(string sourceEndpointName);
 
-    string TranslateToTargetAddress(string sourceAddress);
+    bool TryTranslateToTargetAddress(string sourceAddress, out (string targetAddress, string nearestMatch) result);
 
     string GetEndpointAddress(string endpointName);
 }

--- a/src/NServiceBus.MessagingBridge/IEndpointRegistry.cs
+++ b/src/NServiceBus.MessagingBridge/IEndpointRegistry.cs
@@ -2,7 +2,7 @@
 {
     TargetEndpointDispatcher GetTargetEndpointDispatcher(string sourceEndpointName);
 
-    bool TryTranslateToTargetAddress(string sourceAddress, out (string targetAddress, string nearestMatch) result);
+    bool TryTranslateToTargetAddress(string sourceAddress, out string bestMatch);
 
     string GetEndpointAddress(string endpointName);
 }

--- a/src/NServiceBus.MessagingBridge/MessageShovel.cs
+++ b/src/NServiceBus.MessagingBridge/MessageShovel.cs
@@ -46,8 +46,13 @@ sealed class MessageShovel : IMessageShovel
                 //This is a failed message forwarded to ServiceControl. We need to transform the FailedQ header so that ServiceControl returns the message
                 //to the correct queue/transport on the other side
 
-                //We _do not_ transform the ReplyToAddress header
                 TransformAddressHeader(messageToSend, targetEndpointRegistry, FaultsHeaderKeys.FailedQ);
+
+                //Try to translate the ReplyToAddress, this is needed when e.g.:
+                // 1. An endpoint is migrated to the ServiceControl side before this messages is retried
+                // 2. An endpoint has physical instances on both sides (migration phase) and when retried
+                //    this message can be processed either on one or the other side of the bridge
+                TransformAddressHeader(messageToSend, targetEndpointRegistry, Headers.ReplyToAddress, bestEffort: true);
             }
             else if (IsAuditMessage(messageToSend))
             {
@@ -56,10 +61,11 @@ sealed class MessageShovel : IMessageShovel
             }
             else if (IsRetryMessage(messageToSend))
             {
-                //This is a message retried from ServiceControl. Its ReplyToAddress header has been preserved (as stated above) so we don't need to transform it back
-
                 //Transform the retry ack queue address
                 TransformAddressHeader(messageToSend, targetEndpointRegistry, "ServiceControl.Retry.AcknowledgementQueue");
+
+                //This is a message retried from ServiceControl. We try to translate its ReplyToAddress.
+                TransformAddressHeader(messageToSend, targetEndpointRegistry, Headers.ReplyToAddress, bestEffort: true);
             }
             else
             {
@@ -114,23 +120,29 @@ sealed class MessageShovel : IMessageShovel
         }
         else
         {
-            messageToSend.Headers[Headers.ReplyToAddress] = targetEndpointRegistry.TranslateToTargetAddress(headerValue);
+            TransformAddressHeader(messageToSend, targetEndpointRegistry, Headers.ReplyToAddress);
         }
     }
 
     static void TransformAddressHeader(
         OutgoingMessage messageToSend,
         IEndpointRegistry endpointRegistry,
-        string headerKey)
+        string addressHeaderKey,
+        bool bestEffort = false)
     {
-        if (!messageToSend.Headers.TryGetValue(headerKey, out var headerValue))
+        if (!messageToSend.Headers.TryGetValue(addressHeaderKey, out var sourceAddress))
         {
             return;
         }
 
-        var targetSpecificReplyToAddress = endpointRegistry.TranslateToTargetAddress(headerValue);
-
-        messageToSend.Headers[headerKey] = targetSpecificReplyToAddress;
+        if (endpointRegistry.TryTranslateToTargetAddress(sourceAddress, out (string targetAddress, string nearestMatch) translation))
+        {
+            messageToSend.Headers[addressHeaderKey] = translation.targetAddress;
+        }
+        else if (bestEffort == false)
+        {
+            throw new Exception($"No target address mapping could be found for source address: {sourceAddress}. Ensure names have correct casing as mappings are case-sensitive. Nearest configured match: {translation.nearestMatch}");
+        }
     }
 
     readonly ILogger<MessageShovel> logger;

--- a/src/NServiceBus.MessagingBridge/MessageShovel.cs
+++ b/src/NServiceBus.MessagingBridge/MessageShovel.cs
@@ -52,7 +52,7 @@ sealed class MessageShovel : IMessageShovel
                 // 1. An endpoint is migrated to the ServiceControl side before this messages is retried
                 // 2. An endpoint has physical instances on both sides (migration phase) and when retried
                 //    this message can be processed either on one or the other side of the bridge
-                TransformAddressHeader(messageToSend, targetEndpointRegistry, Headers.ReplyToAddress, bestEffort: true);
+                TransformAddressHeader(messageToSend, targetEndpointRegistry, Headers.ReplyToAddress, throwOnError: false);
             }
             else if (IsAuditMessage(messageToSend))
             {
@@ -65,7 +65,7 @@ sealed class MessageShovel : IMessageShovel
                 TransformAddressHeader(messageToSend, targetEndpointRegistry, "ServiceControl.Retry.AcknowledgementQueue");
 
                 //This is a message retried from ServiceControl. We try to translate its ReplyToAddress.
-                TransformAddressHeader(messageToSend, targetEndpointRegistry, Headers.ReplyToAddress, bestEffort: true);
+                TransformAddressHeader(messageToSend, targetEndpointRegistry, Headers.ReplyToAddress, throwOnError: false);
             }
             else
             {
@@ -102,7 +102,7 @@ sealed class MessageShovel : IMessageShovel
 
     static bool IsRetryMessage(OutgoingMessage messageToSend) => messageToSend.Headers.ContainsKey("ServiceControl.Retry.UniqueMessageId");
 
-    static void TransformRegularMessageReplyToAddress(
+    void TransformRegularMessageReplyToAddress(
         TransferContext transferContext,
         OutgoingMessage messageToSend,
         IEndpointRegistry targetEndpointRegistry)
@@ -124,24 +124,28 @@ sealed class MessageShovel : IMessageShovel
         }
     }
 
-    static void TransformAddressHeader(
+    void TransformAddressHeader(
         OutgoingMessage messageToSend,
         IEndpointRegistry endpointRegistry,
         string addressHeaderKey,
-        bool bestEffort = false)
+        bool throwOnError = true)
     {
         if (!messageToSend.Headers.TryGetValue(addressHeaderKey, out var sourceAddress))
         {
             return;
         }
 
-        if (endpointRegistry.TryTranslateToTargetAddress(sourceAddress, out (string targetAddress, string nearestMatch) translation))
+        if (endpointRegistry.TryTranslateToTargetAddress(sourceAddress, out string bestMatch))
         {
-            messageToSend.Headers[addressHeaderKey] = translation.targetAddress;
+            messageToSend.Headers[addressHeaderKey] = bestMatch;
         }
-        else if (bestEffort == false)
+        else if (throwOnError == false)
         {
-            throw new Exception($"No target address mapping could be found for source address: {sourceAddress}. Ensure names have correct casing as mappings are case-sensitive. Nearest configured match: {translation.nearestMatch}");
+            logger.LogWarning($"Could not translate {sourceAddress} address. Consider using `.HasEndpoint()` method to add missing endpoint declaration.");
+        }
+        else
+        {
+            throw new Exception($"No target address mapping could be found for source address: {sourceAddress}. Ensure names have correct casing as mappings are case-sensitive. Nearest configured match: {bestMatch}");
         }
     }
 

--- a/src/UnitTests/MessageShovelTests.cs
+++ b/src/UnitTests/MessageShovelTests.cs
@@ -194,11 +194,11 @@ public class MessageShovelTests
             return new TargetEndpointDispatcher(targetTransport, rawEndpoint, targetEndpoint.QueueAddress.ToString());
         }
 
-        public bool TryTranslateToTargetAddress(string sourceAddress, out (string targetAddress, string nearestMatch) translation)
+        public bool TryTranslateToTargetAddress(string sourceAddress, out string bestMatch)
         {
             var result = sourceAddress.Split('@').First();
 
-            translation.nearestMatch = translation.targetAddress = result;
+            bestMatch = result;
             return true;
         }
 

--- a/src/UnitTests/MessageShovelTests.cs
+++ b/src/UnitTests/MessageShovelTests.cs
@@ -194,9 +194,12 @@ public class MessageShovelTests
             return new TargetEndpointDispatcher(targetTransport, rawEndpoint, targetEndpoint.QueueAddress.ToString());
         }
 
-        public string TranslateToTargetAddress(string sourceAddress)
+        public bool TryTranslateToTargetAddress(string sourceAddress, out (string targetAddress, string nearestMatch) translation)
         {
-            return sourceAddress.Split('@').First();
+            var result = sourceAddress.Split('@').First();
+
+            translation.nearestMatch = translation.targetAddress = result;
+            return true;
         }
 
         public string GetEndpointAddress(string endpointName) => throw new NotImplementedException();


### PR DESCRIPTION
Backport of #481 which fixes #480 for the `release-3.0` branch