### PR TITLE
Migrate NUnit assertions to the constraint model in preparation of the NUnit 4 upgrade

### DIFF
--- a/src/AcceptanceTests.ASB/.editorconfig
+++ b/src/AcceptanceTests.ASB/.editorconfig
@@ -1,0 +1,9 @@
+[*.cs]
+
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.PS0004.severity = none  # A parameter of type CancellationToken on a private delegate or method should be required
+dotnet_diagnostic.PS0018.severity = none  # Add a CancellationToken parameter
+
+# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
+dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/AcceptanceTests.ASB/AcceptanceTests.ASB.csproj
+++ b/src/AcceptanceTests.ASB/AcceptanceTests.ASB.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 

--- a/src/AcceptanceTests.ASQ/.editorconfig
+++ b/src/AcceptanceTests.ASQ/.editorconfig
@@ -1,0 +1,9 @@
+[*.cs]
+
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.PS0004.severity = none  # A parameter of type CancellationToken on a private delegate or method should be required
+dotnet_diagnostic.PS0018.severity = none  # Add a CancellationToken parameter
+
+# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
+dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/AcceptanceTests.ASQ/AcceptanceTests.ASQ.csproj
+++ b/src/AcceptanceTests.ASQ/AcceptanceTests.ASQ.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 

--- a/src/AcceptanceTests.Learning/.editorconfig
+++ b/src/AcceptanceTests.Learning/.editorconfig
@@ -1,0 +1,9 @@
+[*.cs]
+
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.PS0004.severity = none  # A parameter of type CancellationToken on a private delegate or method should be required
+dotnet_diagnostic.PS0018.severity = none  # Add a CancellationToken parameter
+
+# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
+dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/AcceptanceTests.Learning/AcceptanceTests.Learning.csproj
+++ b/src/AcceptanceTests.Learning/AcceptanceTests.Learning.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 

--- a/src/AcceptanceTests.Msmq/.editorconfig
+++ b/src/AcceptanceTests.Msmq/.editorconfig
@@ -1,0 +1,9 @@
+[*.cs]
+
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.PS0004.severity = none  # A parameter of type CancellationToken on a private delegate or method should be required
+dotnet_diagnostic.PS0018.severity = none  # Add a CancellationToken parameter
+
+# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
+dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/AcceptanceTests.Msmq/AcceptanceTests.Msmq.csproj
+++ b/src/AcceptanceTests.Msmq/AcceptanceTests.Msmq.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 

--- a/src/AcceptanceTests.Msmq/Publishing_custom_address.cs
+++ b/src/AcceptanceTests.Msmq/Publishing_custom_address.cs
@@ -35,7 +35,7 @@ class Publishing_custom_address : BridgeAcceptanceTest
                 }))
             .WithEndpoint<Subscriber>()
             .Done(c => c.SubscriberGotEvent)
-            .Run().ConfigureAwait(false);
+            .Run();
 
         Assert.That(context.SubscriberGotEvent, Is.True);
     }

--- a/src/AcceptanceTests.Msmq/Publishing_custom_address.cs
+++ b/src/AcceptanceTests.Msmq/Publishing_custom_address.cs
@@ -37,7 +37,7 @@ class Publishing_custom_address : BridgeAcceptanceTest
             .Done(c => c.SubscriberGotEvent)
             .Run();
 
-        Assert.IsTrue(context.SubscriberGotEvent);
+        Assert.That(context.SubscriberGotEvent, Is.True);
     }
 
     public class Context : ScenarioContext

--- a/src/AcceptanceTests.Msmq/Publishing_custom_address.cs
+++ b/src/AcceptanceTests.Msmq/Publishing_custom_address.cs
@@ -35,7 +35,7 @@ class Publishing_custom_address : BridgeAcceptanceTest
                 }))
             .WithEndpoint<Subscriber>()
             .Done(c => c.SubscriberGotEvent)
-            .Run();
+            .Run().ConfigureAwait(false);
 
         Assert.That(context.SubscriberGotEvent, Is.True);
     }

--- a/src/AcceptanceTests.RabbitMQ/.editorconfig
+++ b/src/AcceptanceTests.RabbitMQ/.editorconfig
@@ -1,0 +1,9 @@
+[*.cs]
+
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.PS0004.severity = none  # A parameter of type CancellationToken on a private delegate or method should be required
+dotnet_diagnostic.PS0018.severity = none  # Add a CancellationToken parameter
+
+# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
+dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/AcceptanceTests.RabbitMQ/AcceptanceTests.RabbitMQ.csproj
+++ b/src/AcceptanceTests.RabbitMQ/AcceptanceTests.RabbitMQ.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 

--- a/src/AcceptanceTests.SQS/AcceptanceTests.SQS.csproj
+++ b/src/AcceptanceTests.SQS/AcceptanceTests.SQS.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 

--- a/src/AcceptanceTests.SqlServer/.editorconfig
+++ b/src/AcceptanceTests.SqlServer/.editorconfig
@@ -1,0 +1,9 @@
+[*.cs]
+
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.PS0004.severity = none  # A parameter of type CancellationToken on a private delegate or method should be required
+dotnet_diagnostic.PS0018.severity = none  # Add a CancellationToken parameter
+
+# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
+dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/AcceptanceTests.SqlServer/AcceptanceTests.SqlServer.csproj
+++ b/src/AcceptanceTests.SqlServer/AcceptanceTests.SqlServer.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 

--- a/src/AcceptanceTests.SqlServer/SqlTests/Separate_instances.cs
+++ b/src/AcceptanceTests.SqlServer/SqlTests/Separate_instances.cs
@@ -57,7 +57,7 @@ public class Separate_instances : BridgeAcceptanceTest
                 bridgeConfiguration.RunInReceiveOnlyTransactionMode();
             })
             .Done(c => c.SubscriberGotEvent)
-            .Run().ConfigureAwait(false);
+            .Run();
 
         Assert.That(context.SubscriberGotEvent, Is.True);
     }

--- a/src/AcceptanceTests.SqlServer/SqlTests/Separate_instances.cs
+++ b/src/AcceptanceTests.SqlServer/SqlTests/Separate_instances.cs
@@ -59,7 +59,7 @@ public class Separate_instances : BridgeAcceptanceTest
             .Done(c => c.SubscriberGotEvent)
             .Run();
 
-        Assert.IsTrue(context.SubscriberGotEvent);
+        Assert.That(context.SubscriberGotEvent, Is.True);
     }
 
     public class Context : ScenarioContext

--- a/src/AcceptanceTests.SqlServer/SqlTests/Separate_instances.cs
+++ b/src/AcceptanceTests.SqlServer/SqlTests/Separate_instances.cs
@@ -57,7 +57,7 @@ public class Separate_instances : BridgeAcceptanceTest
                 bridgeConfiguration.RunInReceiveOnlyTransactionMode();
             })
             .Done(c => c.SubscriberGotEvent)
-            .Run();
+            .Run().ConfigureAwait(false);
 
         Assert.That(context.SubscriberGotEvent, Is.True);
     }

--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 

--- a/src/AcceptanceTests/Shared/Audit.cs
+++ b/src/AcceptanceTests/Shared/Audit.cs
@@ -41,7 +41,7 @@ public class Audit : BridgeAcceptanceTest
         {
             if (ctx.ReceivedMessageHeaders.TryGetValue(header.Key, out var receivedHeaderValue))
             {
-                Assert.AreEqual(header.Value, receivedHeaderValue,
+                Assert.That(receivedHeaderValue, Is.EqualTo(header.Value),
                     $"{header.Key} is not the same on processed message and audit message.");
             }
         }

--- a/src/AcceptanceTests/Shared/Audit.cs
+++ b/src/AcceptanceTests/Shared/Audit.cs
@@ -36,7 +36,7 @@ public class Audit : BridgeAcceptanceTest
             .Done(c => c.MessageAudited)
             .Run();
 
-        Assert.IsTrue(ctx.MessageAudited);
+        Assert.That(ctx.MessageAudited, Is.True);
         foreach (var header in ctx.AuditMessageHeaders)
         {
             if (ctx.ReceivedMessageHeaders.TryGetValue(header.Key, out var receivedHeaderValue))

--- a/src/AcceptanceTests/Shared/Error.cs
+++ b/src/AcceptanceTests/Shared/Error.cs
@@ -43,7 +43,7 @@ public class Error : BridgeAcceptanceTest
         {
             if (ctx.ReceivedMessageHeaders.TryGetValue(header.Key, out var receivedHeaderValue))
             {
-                Assert.AreEqual(header.Value, receivedHeaderValue,
+                Assert.That(receivedHeaderValue, Is.EqualTo(header.Value),
                     $"{header.Key} is not the same on processed message and audit message.");
             }
         }

--- a/src/AcceptanceTests/Shared/Error.cs
+++ b/src/AcceptanceTests/Shared/Error.cs
@@ -38,7 +38,7 @@ public class Error : BridgeAcceptanceTest
             .Done(c => c.MessageFailed)
             .Run();
 
-        Assert.IsTrue(ctx.MessageFailed);
+        Assert.That(ctx.MessageFailed, Is.True);
         foreach (var header in ctx.FailedMessageHeaders)
         {
             if (ctx.ReceivedMessageHeaders.TryGetValue(header.Key, out var receivedHeaderValue))

--- a/src/AcceptanceTests/Shared/Publishing.cs
+++ b/src/AcceptanceTests/Shared/Publishing.cs
@@ -31,7 +31,7 @@ class Publishing : BridgeAcceptanceTest
             .Done(c => c.SubscriberGotEvent)
             .Run();
 
-        Assert.IsTrue(context.SubscriberGotEvent);
+        Assert.That(context.SubscriberGotEvent, Is.True);
     }
 
     public class Context : ScenarioContext

--- a/src/AcceptanceTests/Shared/Request_reply.cs
+++ b/src/AcceptanceTests/Shared/Request_reply.cs
@@ -27,7 +27,7 @@ public class Request_reply : BridgeAcceptanceTest
                     .Done(c => c.SendingEndpointGotResponse)
                     .Run();
 
-        Assert.IsTrue(ctx.SendingEndpointGotResponse);
+        Assert.That(ctx.SendingEndpointGotResponse, Is.True);
     }
 
     public class Context : ScenarioContext

--- a/src/AcceptanceTests/Shared/Request_reply_custom_address.cs
+++ b/src/AcceptanceTests/Shared/Request_reply_custom_address.cs
@@ -29,7 +29,7 @@ public class Request_reply_custom_address : BridgeAcceptanceTest
                     .Done(c => c.SendingEndpointGotResponse)
                     .Run();
 
-        Assert.IsTrue(ctx.SendingEndpointGotResponse);
+        Assert.That(ctx.SendingEndpointGotResponse, Is.True);
     }
 
     public class Context : ScenarioContext

--- a/src/AcceptanceTests/Shared/Retry.cs
+++ b/src/AcceptanceTests/Shared/Retry.cs
@@ -43,10 +43,10 @@ public class Retry : BridgeAcceptanceTest
             .Done(c => c.GotRetrySuccessfullAck && c.MessageAudited)
             .Run();
 
-        Assert.IsTrue(ctx.MessageFailed);
-        Assert.IsTrue(ctx.RetryDelivered);
-        Assert.IsTrue(ctx.GotRetrySuccessfullAck);
-        Assert.IsTrue(ctx.MessageAudited);
+        Assert.That(ctx.MessageFailed, Is.True);
+        Assert.That(ctx.RetryDelivered, Is.True);
+        Assert.That(ctx.GotRetrySuccessfullAck, Is.True);
+        Assert.That(ctx.MessageAudited, Is.True);
 
         foreach (var header in ctx.FailedMessageHeaders)
         {

--- a/src/AcceptanceTests/Shared/Retry.cs
+++ b/src/AcceptanceTests/Shared/Retry.cs
@@ -52,7 +52,7 @@ public class Retry : BridgeAcceptanceTest
         {
             if (ctx.ReceivedMessageHeaders.TryGetValue(header.Key, out var receivedHeaderValue))
             {
-                Assert.AreEqual(header.Value, receivedHeaderValue,
+                Assert.That(receivedHeaderValue, Is.EqualTo(header.Value),
                     $"{header.Key} is not the same on processed message and message sent to the error queue");
             }
         }

--- a/src/AcceptanceTests/Shared/Retry.cs
+++ b/src/AcceptanceTests/Shared/Retry.cs
@@ -43,10 +43,13 @@ public class Retry : BridgeAcceptanceTest
             .Done(c => c.GotRetrySuccessfullAck && c.MessageAudited)
             .Run();
 
-        Assert.That(ctx.MessageFailed, Is.True);
-        Assert.That(ctx.RetryDelivered, Is.True);
-        Assert.That(ctx.GotRetrySuccessfullAck, Is.True);
-        Assert.That(ctx.MessageAudited, Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(ctx.MessageFailed, Is.True);
+            Assert.That(ctx.RetryDelivered, Is.True);
+            Assert.That(ctx.GotRetrySuccessfullAck, Is.True);
+            Assert.That(ctx.MessageAudited, Is.True);
+        });
 
         foreach (var header in ctx.FailedMessageHeaders)
         {

--- a/src/AcceptanceTests/Shared/Send_local.cs
+++ b/src/AcceptanceTests/Shared/Send_local.cs
@@ -28,7 +28,7 @@ public class Send_local : BridgeAcceptanceTest
                     .Done(c => c.MessageReceived)
                     .Run();
 
-        Assert.IsTrue(ctx.MessageReceived);
+        Assert.That(ctx.MessageReceived, Is.True);
     }
 
     public class Context : ScenarioContext

--- a/src/AcceptanceTests/Shared/Subscribing.cs
+++ b/src/AcceptanceTests/Shared/Subscribing.cs
@@ -33,7 +33,7 @@ class Subscribing : BridgeAcceptanceTest
             .Done(c => c.SubscriberGotEvent)
             .Run();
 
-        Assert.IsTrue(context.SubscriberGotEvent);
+        Assert.That(context.SubscriberGotEvent, Is.True);
     }
 
     public class Context : ScenarioContext

--- a/src/AcceptanceTests/Shared/TransferFailureTests.cs
+++ b/src/AcceptanceTests/Shared/TransferFailureTests.cs
@@ -37,8 +37,9 @@ public class TransferFailureTests : BridgeAcceptanceTest
             .Done(c => c.MessageFailed)
             .Run();
 
-        Assert.IsTrue(ctx.MessageFailed, "Message did not fail");
-        Assert.IsTrue(ctx.FailedMessageHeaders.ContainsKey(FailedQHeader),
+        Assert.That(ctx.MessageFailed, Is.True, "Message did not fail");
+        Assert.That(ctx.FailedMessageHeaders.ContainsKey(FailedQHeader),
+            Is.True,
             $"Failed message headers does not contain {FailedQHeader}");
     }
 
@@ -68,8 +69,9 @@ public class TransferFailureTests : BridgeAcceptanceTest
             .Done(c => c.MessageFailed)
             .Run();
 
-        Assert.IsTrue(ctx.MessageFailed, "Message did not fail");
-        Assert.IsTrue(ctx.FailedMessageHeaders.ContainsKey(FailedQHeader),
+        Assert.That(ctx.MessageFailed, Is.True, "Message did not fail");
+        Assert.That(ctx.FailedMessageHeaders.ContainsKey(FailedQHeader),
+            Is.True,
             $"Failed message headers does not contain {FailedQHeader}");
     }
 

--- a/src/AcceptanceTests/Shared/TransferFailureTests.cs
+++ b/src/AcceptanceTests/Shared/TransferFailureTests.cs
@@ -37,10 +37,13 @@ public class TransferFailureTests : BridgeAcceptanceTest
             .Done(c => c.MessageFailed)
             .Run();
 
-        Assert.That(ctx.MessageFailed, Is.True, "Message did not fail");
-        Assert.That(ctx.FailedMessageHeaders.ContainsKey(FailedQHeader),
-            Is.True,
-            $"Failed message headers does not contain {FailedQHeader}");
+        Assert.Multiple(() =>
+        {
+            Assert.That(ctx.MessageFailed, Is.True, "Message did not fail");
+            Assert.That(ctx.FailedMessageHeaders.ContainsKey(FailedQHeader),
+                Is.True,
+                $"Failed message headers does not contain {FailedQHeader}");
+        });
     }
 
     [Test]
@@ -69,10 +72,13 @@ public class TransferFailureTests : BridgeAcceptanceTest
             .Done(c => c.MessageFailed)
             .Run();
 
-        Assert.That(ctx.MessageFailed, Is.True, "Message did not fail");
-        Assert.That(ctx.FailedMessageHeaders.ContainsKey(FailedQHeader),
-            Is.True,
-            $"Failed message headers does not contain {FailedQHeader}");
+        Assert.Multiple(() =>
+        {
+            Assert.That(ctx.MessageFailed, Is.True, "Message did not fail");
+            Assert.That(ctx.FailedMessageHeaders.ContainsKey(FailedQHeader),
+                Is.True,
+                $"Failed message headers does not contain {FailedQHeader}");
+        });
     }
 
     public class Sender : EndpointConfigurationBuilder

--- a/src/UnitTests/BridgeConfigurationTests.cs
+++ b/src/UnitTests/BridgeConfigurationTests.cs
@@ -17,7 +17,7 @@ public class BridgeConfigurationTests
 
         var ex = Assert.Throws<InvalidOperationException>(() => FinalizeConfiguration(configuration));
 
-        StringAssert.Contains("At least two", ex.Message);
+        Assert.That(ex.Message, Does.Contain("At least two"));
     }
 
     [Test]
@@ -30,8 +30,8 @@ public class BridgeConfigurationTests
 
         var ex = Assert.Throws<InvalidOperationException>(() => FinalizeConfiguration(configuration));
 
-        StringAssert.Contains("At least one", ex.Message);
-        StringAssert.Contains("some, someother", ex.Message);
+        Assert.That(ex.Message, Does.Contain("At least one"));
+        Assert.That(ex.Message, Does.Contain("some, someother"));
     }
 
     [Test]
@@ -64,9 +64,9 @@ public class BridgeConfigurationTests
         configuration.AddTransport(someOtherTransport);
         var ex = Assert.Throws<InvalidOperationException>(() => FinalizeConfiguration(configuration));
 
-        StringAssert.Contains("It is not allowed to register the bridge error queue as an endpoint, please change the error queue or remove the endpoint mapping", ex.Message);
-        StringAssert.Contains(bridgeErrorQueue, ex.Message);
-        StringAssert.Contains(transport.Name, ex.Message);
+        Assert.That(ex.Message, Does.Contain("It is not allowed to register the bridge error queue as an endpoint, please change the error queue or remove the endpoint mapping"));
+        Assert.That(ex.Message, Does.Contain(bridgeErrorQueue));
+        Assert.That(ex.Message, Does.Contain(transport.Name));
     }
 
     [Test]
@@ -74,7 +74,7 @@ public class BridgeConfigurationTests
     {
         var transport = new BridgeTransport(new SomeTransport());
 
-        Assert.AreEqual(Math.Max(2, Environment.ProcessorCount), transport.Concurrency);
+        Assert.That(transport.Concurrency, Is.EqualTo(Math.Max(2, Environment.ProcessorCount)));
     }
 
     [Test]
@@ -95,8 +95,8 @@ public class BridgeConfigurationTests
 
         var ex = Assert.Throws<InvalidOperationException>(() => FinalizeConfiguration(configuration));
 
-        StringAssert.Contains("Endpoints can only be associated with a single transport", ex.Message);
-        StringAssert.Contains(duplicatedEndpointName, ex.Message);
+        Assert.That(ex.Message, Does.Contain("Endpoints can only be associated with a single transport"));
+        Assert.That(ex.Message, Does.Contain(duplicatedEndpointName));
     }
 
     [Test]
@@ -119,9 +119,9 @@ public class BridgeConfigurationTests
 
         var ex = Assert.Throws<InvalidOperationException>(() => FinalizeConfiguration(configuration));
 
-        StringAssert.Contains("The following events have a publisher configured that is unknown", ex.Message);
-        StringAssert.Contains(typeof(MyEvent).FullName, ex.Message);
-        StringAssert.Contains("NotThePublisher", ex.Message);
+        Assert.That(ex.Message, Does.Contain("The following events have a publisher configured that is unknown"));
+        Assert.That(ex.Message, Does.Contain(typeof(MyEvent).FullName));
+        Assert.That(ex.Message, Does.Contain("NotThePublisher"));
     }
 
     [Test]
@@ -150,10 +150,10 @@ public class BridgeConfigurationTests
 
         var ex = Assert.Throws<InvalidOperationException>(() => FinalizeConfiguration(configuration));
 
-        StringAssert.Contains("Events can only be associated with a single publisher", ex.Message);
-        StringAssert.Contains(typeof(MyEvent).FullName, ex.Message);
-        StringAssert.Contains("Publisher", ex.Message);
-        StringAssert.Contains("OtherEndpoint", ex.Message);
+        Assert.That(ex.Message, Does.Contain("Events can only be associated with a single publisher"));
+        Assert.That(ex.Message, Does.Contain(typeof(MyEvent).FullName));
+        Assert.That(ex.Message, Does.Contain("Publisher"));
+        Assert.That(ex.Message, Does.Contain("OtherEndpoint"));
     }
 
     [Test]
@@ -225,11 +225,11 @@ public class BridgeConfigurationTests
 
         var finalizedConfiguration = FinalizeConfiguration(configuration);
 
-        Assert.AreEqual("EndpointWithDefaultAddress", finalizedConfiguration.TransportConfigurations
-            .Single(t => t.Name == transportWithDefaultAddress.Name).Endpoints.Single().QueueAddress.ToString());
+        Assert.That(finalizedConfiguration.TransportConfigurations
+            .Single(t => t.Name == transportWithDefaultAddress.Name).Endpoints.Single().QueueAddress.ToString(), Is.EqualTo("EndpointWithDefaultAddress"));
 
-        Assert.AreEqual(customAddress, finalizedConfiguration.TransportConfigurations
-            .Single(t => t.Name == transportWithCustomAddress.Name).Endpoints.Single().QueueAddress.ToString());
+        Assert.That(finalizedConfiguration.TransportConfigurations
+            .Single(t => t.Name == transportWithCustomAddress.Name).Endpoints.Single().QueueAddress.ToString(), Is.EqualTo(customAddress));
     }
 
     [Test]

--- a/src/UnitTests/BridgeEndpointConfigurationTests.cs
+++ b/src/UnitTests/BridgeEndpointConfigurationTests.cs
@@ -13,10 +13,10 @@ public class BridgeEndpointConfigurationTests
         endpoint.RegisterPublisher(typeof(MyOtherEvent), "Shipping");
 
         var billingSubscription = endpoint.Subscriptions.SingleOrDefault(t => t.EventTypeAssemblyQualifiedName == typeof(MyEvent).AssemblyQualifiedName);
-        Assert.AreEqual("Billing", billingSubscription.Publisher);
+        Assert.That(billingSubscription.Publisher, Is.EqualTo("Billing"));
 
         var shippingSubscription = endpoint.Subscriptions.SingleOrDefault(t => t.EventTypeAssemblyQualifiedName == typeof(MyOtherEvent).AssemblyQualifiedName);
-        Assert.AreEqual("Shipping", shippingSubscription.Publisher);
+        Assert.That(shippingSubscription.Publisher, Is.EqualTo("Shipping"));
 
     }
 

--- a/src/UnitTests/ExceptionHeaderHelperFixture.cs
+++ b/src/UnitTests/ExceptionHeaderHelperFixture.cs
@@ -31,9 +31,9 @@ public class ExceptionHeaderHelperFixture
         {
             ExceptionHeaderHelper.SetExceptionHeaders(headers, outer);
 
-            Assert.AreEqual(10000, headers["NServiceBus.MessagingBridge.ExceptionInfo.Message"].Length, "Message");
-            Assert.AreEqual(16384, headers["NServiceBus.MessagingBridge.ExceptionInfo.StackTrace"].Length, "Stacktrace");
-            Assert.AreEqual(20000, headers["NServiceBus.MessagingBridge.ExceptionInfo.Data.b"].Length, "b");
+            Assert.That(headers["NServiceBus.MessagingBridge.ExceptionInfo.Message"].Length, Is.EqualTo(10000), "Message");
+            Assert.That(headers["NServiceBus.MessagingBridge.ExceptionInfo.StackTrace"].Length, Is.EqualTo(16384), "Stacktrace");
+            Assert.That(headers["NServiceBus.MessagingBridge.ExceptionInfo.Data.b"].Length, Is.EqualTo(20000), "b");
         }
     }
 }

--- a/src/UnitTests/MessageShovelTests.cs
+++ b/src/UnitTests/MessageShovelTests.cs
@@ -17,7 +17,7 @@ public class MessageShovelTests
     {
         var transferDetails = await Transfer(replyToAddress: "SendingEndpointReplyAddress@MyMachine");
 
-        Assert.AreEqual("SendingEndpointReplyAddress", transferDetails.OutgoingOperation.Message.Headers[Headers.ReplyToAddress]);
+        Assert.That(transferDetails.OutgoingOperation.Message.Headers[Headers.ReplyToAddress], Is.EqualTo("SendingEndpointReplyAddress"));
     }
 
     [Test]
@@ -25,7 +25,7 @@ public class MessageShovelTests
     {
         var transferDetails = await Transfer(failedQueueAddress: "error@MyMachine");
 
-        Assert.AreEqual("error", transferDetails.OutgoingOperation.Message.Headers[FaultsHeaderKeys.FailedQ]);
+        Assert.That(transferDetails.OutgoingOperation.Message.Headers[FaultsHeaderKeys.FailedQ], Is.EqualTo("error"));
     }
 
     [Test]
@@ -33,7 +33,7 @@ public class MessageShovelTests
     {
         var transferDetails = await Transfer(retryAckQueueAddress: "error@MyMachine");
 
-        Assert.AreEqual("error", transferDetails.OutgoingOperation.Message.Headers["ServiceControl.Retry.AcknowledgementQueue"]);
+        Assert.That(transferDetails.OutgoingOperation.Message.Headers["ServiceControl.Retry.AcknowledgementQueue"], Is.EqualTo("error"));
     }
 
     [Test]
@@ -41,7 +41,7 @@ public class MessageShovelTests
     {
         var transferDetails = await Transfer(retryAckQueueAddress: "error@MyMachine", isAuditMessage: true);
 
-        Assert.AreEqual("error@MyMachine", transferDetails.OutgoingOperation.Message.Headers["ServiceControl.Retry.AcknowledgementQueue"]);
+        Assert.That(transferDetails.OutgoingOperation.Message.Headers["ServiceControl.Retry.AcknowledgementQueue"], Is.EqualTo("error@MyMachine"));
     }
 
     [Test]
@@ -59,7 +59,7 @@ public class MessageShovelTests
     {
         var transferDetails = await Transfer();
 
-        Assert.AreEqual("SourceTransport->TargetTransport", transferDetails.OutgoingOperation.Message.Headers[BridgeHeaders.Transfer]);
+        Assert.That(transferDetails.OutgoingOperation.Message.Headers[BridgeHeaders.Transfer], Is.EqualTo("SourceTransport->TargetTransport"));
     }
 
     [Test]
@@ -71,13 +71,13 @@ public class MessageShovelTests
             transportTransaction: transportTransaction,
             passTransportTransaction: false);
 
-        Assert.AreNotSame(transportTransaction, transferWithoutTransaction.TransportTransaction);
+        Assert.That(transferWithoutTransaction.TransportTransaction, Is.Not.SameAs(transportTransaction));
 
         var transferWithTransaction = await Transfer(
              transportTransaction: transportTransaction,
              passTransportTransaction: true);
 
-        Assert.AreSame(transportTransaction, transferWithTransaction.TransportTransaction);
+        Assert.That(transferWithTransaction.TransportTransaction, Is.SameAs(transportTransaction));
     }
 
     [Test]
@@ -87,7 +87,7 @@ public class MessageShovelTests
 
         var transferDetails = await Transfer(targetAddress: targetEndpointAddress);
 
-        Assert.AreEqual(targetEndpointAddress, transferDetails.OutgoingOperation.Destination);
+        Assert.That(transferDetails.OutgoingOperation.Destination, Is.EqualTo(targetEndpointAddress));
     }
 
     static async Task<TransferDetails> Transfer(

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR contains all changes related to assertion model according to the [constraint assertion model](https://docs.nunit.org/articles/nunit/writing-tests/assertions/assertion-models/constraint.html).

Using a script, we apply all [assertion rules](https://docs.nunit.org/articles/nunit-analyzers/NUnit-Analyzers.html#assertion-rules-nunit2001---) provided by the NUnit.Analyzers package. In addition, some manual interventions are done when applicable.

## Plan of action

- [x] ⚠️ Build the solution and resolve any remaining errors or warnings
- [x] ✅ Review the assertions commit by commit
- [x] 👀 Invite another pair of eyes to re-review
🚀  Squash and merge
