### PR TITLE
Store queue and machine name in properties if queueAddress specified

### DIFF
--- a/src/NServiceBus.MessagingBridge/Configuration/BridgeEndpoint.cs
+++ b/src/NServiceBus.MessagingBridge/Configuration/BridgeEndpoint.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Transport;
 
     /// <summary>
@@ -26,7 +27,21 @@
             ArgumentException.ThrowIfNullOrWhiteSpace(queueAddress);
 
             Name = name;
-            QueueAddress = new QueueAddress(queueAddress);
+
+            if (queueAddress.Count(w => w == '@') == 1)
+            {
+                Dictionary<string, string> properties = [];
+                var queueAddressSplit = queueAddress.Split('@');
+
+                properties.Add("queue", queueAddressSplit[0]);
+                properties.Add("machine", queueAddressSplit[1]);
+
+                QueueAddress = new QueueAddress(queueAddressSplit[0], properties: properties);
+            }
+            else
+            {
+                QueueAddress = new QueueAddress(queueAddress);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This is relation to specifying [custom queue addresses](https://docs.particular.net/nservicebus/bridge/configuration#custom-queue-address) for MSMQ endpoints running on a different server to the bridge.

Currently we append @Machine to queue names if there are no corresponding properties on the QueueAddress object in [MsmqTransportInfrastructure.TranslateAddress](https://github.com/Particular/NServiceBus.Transport.Msmq/blob/master/src/NServiceBus.Transport.Msmq/MsmqTransportInfrastructure.cs#L25) method.

When the bridge creates the QueueAddress object in the [BridgeEndpoint constructor](https://github.com/Particular/NServiceBus.MessagingBridge/blob/master/src/NServiceBus.MessagingBridge/Configuration/BridgeEndpoint.cs#L23), it passes in the queueAddress the user specified but that's it - there are no parameters passes in for the properties that are required to not auto append the current machine name.

The [QueueAddress constructor](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/Transports/QueueAddress.cs#L17) does not set them in any way hence when the TranslateAddress method is run in the MSMQ transport, the machine name is appended to the QueueAddress.BaseAddress (which already contains the user specified machine name) which causes errors as you end up with: `queuename@userSpecifiedMachine@BridgeAppendedMachine`