### PR TITLE
Add support for duplicate endpoints running on both sides of the bridge

### DIFF
--- a/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
+++ b/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
@@ -67,6 +67,14 @@ class EndpointRegistry : IEndpointRegistry
             return true;
         }
 
+        // For messages coming from duplicate endpoints running on the "proxy" side of the bridge,
+        // the address does not need to be translated since it will already be correct
+        if (targetEndpointAddressMappings.Values.Contains(sourceAddress))
+        {
+            bestMatch = sourceAddress;
+            return true;
+        }
+
         bestMatch = GetClosestMatchForExceptionMessage(sourceAddress, targetEndpointAddressMappings.Keys);
         return false;
     }


### PR DESCRIPTION
Fix issue where duplicate endpoints are still running on the "proxy" or unregistered side of the bridge and competing with the bridge for messages