### PR TITLE
Make TranslateReplyToAddressForFailedMessages the default behaviour

### DIFF
--- a/src/AcceptanceTests/Shared/Retry.cs
+++ b/src/AcceptanceTests/Shared/Retry.cs
@@ -14,7 +14,7 @@ public class Retry : BridgeAcceptanceTest
 {
     [TestCase(true)]
     [TestCase(false)]
-    public async Task Should_work(bool translateReplyToAdressForFailedMessages)
+    public async Task Should_work(bool doNotTranslateReplyToAdressForFailedMessages)
     {
         var ctx = await Scenario.Define<Context>()
             .WithEndpoint<ProcessingEndpoint>(builder =>
@@ -25,9 +25,9 @@ public class Retry : BridgeAcceptanceTest
             .WithEndpoint<FakeSCError>()
             .WithBridge(bridgeConfiguration =>
             {
-                if (translateReplyToAdressForFailedMessages)
+                if (doNotTranslateReplyToAdressForFailedMessages)
                 {
-                    bridgeConfiguration.TranslateReplyToAddressForFailedMessages();
+                    bridgeConfiguration.DoNotTranslateReplyToAddressForFailedMessages();
                 }
                 var bridgeTransport = new TestableBridgeTransport(DefaultTestServer.GetTestTransportDefinition())
                 {
@@ -54,7 +54,7 @@ public class Retry : BridgeAcceptanceTest
         {
             if (ctx.ReceivedMessageHeaders.TryGetValue(header.Key, out var receivedHeaderValue))
             {
-                if (translateReplyToAdressForFailedMessages && header.Key == Headers.ReplyToAddress)
+                if (!doNotTranslateReplyToAdressForFailedMessages && header.Key == Headers.ReplyToAddress)
                 {
                     Assert.That(receivedHeaderValue.Contains(nameof(ProcessingEndpoint), StringComparison.InvariantCultureIgnoreCase), Is.True,
                         $"The ReplyToAddress received by ServiceControl ({TransportBeingTested} physical address) should contain the logical name of the endpoint.");
@@ -91,7 +91,6 @@ public class Retry : BridgeAcceptanceTest
             .WithEndpoint<FakeSCError>()
             .WithBridge(bridgeConfiguration =>
             {
-                bridgeConfiguration.TranslateReplyToAddressForFailedMessages();
                 var bridgeTransport = new TestableBridgeTransport(DefaultTestServer.GetTestTransportDefinition())
                 {
                     Name = "DefaultTestingTransport"

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
 	<PropertyGroup>
-		<MinVerMinimumMajorMinor>3.0</MinVerMinimumMajorMinor>
+		<MinVerMinimumMajorMinor>4.0</MinVerMinimumMajorMinor>
 		<MinVerAutoIncrement>minor</MinVerAutoIncrement>
 	</PropertyGroup>
 

--- a/src/NServiceBus.MessagingBridge/Configuration/BridgeConfiguration.cs
+++ b/src/NServiceBus.MessagingBridge/Configuration/BridgeConfiguration.cs
@@ -10,7 +10,7 @@ namespace NServiceBus
     /// <summary>
     /// Configuration options for bridging multiple transports
     /// </summary>
-    public class BridgeConfiguration
+    public partial class BridgeConfiguration
     {
         /// <summary>
         /// Configures the bridge with the given transport
@@ -38,9 +38,9 @@ namespace NServiceBus
         public void DoNotEnforceBestPractices() => allowMultiplePublishersSameEvent = true;
 
         /// <summary>
-        /// Enable ReplyTo address translation on the bridge, which allows seamless retry of messages when endpoints move from one side of the bridge to another
+        /// Disable ReplyTo address translation on the bridge for failed messages
         /// </summary>
-        public void TranslateReplyToAddressForFailedMessages() => translateReplyToAddressForFailedMessages = true;
+        public void DoNotTranslateReplyToAddressForFailedMessages() => translateReplyToAddressForFailedMessages = false;
 
         internal FinalizedBridgeConfiguration FinalizeConfiguration(ILogger<BridgeConfiguration> logger)
         {
@@ -175,7 +175,7 @@ namespace NServiceBus
 
         bool runInReceiveOnlyTransactionMode;
         bool allowMultiplePublishersSameEvent;
-        bool translateReplyToAddressForFailedMessages;
+        bool translateReplyToAddressForFailedMessages = true;
 
         readonly List<BridgeTransport> transportConfigurations = [];
     }

--- a/src/NServiceBus.MessagingBridge/FodyWeavers.xml
+++ b/src/NServiceBus.MessagingBridge/FodyWeavers.xml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers GenerateXsd="false">
+  <Janitor />
+  <Obsolete HideObsoleteMembers="never" />
+</Weavers>

--- a/src/NServiceBus.MessagingBridge/FodyWeavers.xml
+++ b/src/NServiceBus.MessagingBridge/FodyWeavers.xml
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers GenerateXsd="false">
-  <Janitor />
   <Obsolete HideObsoleteMembers="never" />
 </Weavers>

--- a/src/NServiceBus.MessagingBridge/Heartbeats/HeartbeatSender.cs
+++ b/src/NServiceBus.MessagingBridge/Heartbeats/HeartbeatSender.cs
@@ -8,7 +8,6 @@ using Logging;
 using ServiceControl.Plugin.Heartbeat.Messages;
 using Transport;
 
-[Janitor.SkipWeaving]
 class HeartbeatSender(
     IMessageDispatcher dispatcher,
     HostInformation hostInfo,

--- a/src/NServiceBus.MessagingBridge/Heartbeats/HeartbeatSender.cs
+++ b/src/NServiceBus.MessagingBridge/Heartbeats/HeartbeatSender.cs
@@ -8,6 +8,7 @@ using Logging;
 using ServiceControl.Plugin.Heartbeat.Messages;
 using Transport;
 
+[Janitor.SkipWeaving]
 class HeartbeatSender(
     IMessageDispatcher dispatcher,
     HostInformation hostInfo,

--- a/src/NServiceBus.MessagingBridge/NServiceBus.MessagingBridge.csproj
+++ b/src/NServiceBus.MessagingBridge/NServiceBus.MessagingBridge.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -14,7 +14,6 @@
   <ItemGroup>
     <PackageReference Include="Particular.Packaging" Version="4.1.0" PrivateAssets="All" />
     <PackageReference Include="Fody" Version="6.8.1" PrivateAssets="All" />
-    <PackageReference Include="Janitor.Fody" Version="1.9.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
   </ItemGroup>
   

--- a/src/NServiceBus.MessagingBridge/NServiceBus.MessagingBridge.csproj
+++ b/src/NServiceBus.MessagingBridge/NServiceBus.MessagingBridge.csproj
@@ -13,8 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="Particular.Packaging" Version="4.1.0" PrivateAssets="All" />
+    <PackageReference Include="Fody" Version="6.8.1" PrivateAssets="All" />
+    <PackageReference Include="Janitor.Fody" Version="1.9.0" PrivateAssets="All" />
+    <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <InternalsVisibleTo Include="UnitTests" Key="$(NServiceBusTestsKey)" />
     <InternalsVisibleTo Include="AcceptanceTesting" Key="$(NServiceBusTestsKey)" />

--- a/src/NServiceBus.MessagingBridge/obsoletes-v4.cs
+++ b/src/NServiceBus.MessagingBridge/obsoletes-v4.cs
@@ -6,7 +6,7 @@
         /// Enable ReplyTo address translation on the bridge, which allows seamless retry of messages when endpoints move from one side of the bridge to another
         /// </summary>
         [ObsoleteEx(
-        Message = "The bridge now translates ReplyTo addresses for failed messages by default. To opt out, use DoNotTranslateReplyToAddressForFailedMessages",
+        Message = "The bridge now translates ReplyTo addresses for failed messages by default so this method call is no longer necessary.",
         RemoveInVersion = "5.0",
         TreatAsErrorFromVersion = "4.0")]
         public void TranslateReplyToAddressForFailedMessages() => translateReplyToAddressForFailedMessages = true;

--- a/src/NServiceBus.MessagingBridge/obsoletes-v4.cs
+++ b/src/NServiceBus.MessagingBridge/obsoletes-v4.cs
@@ -1,0 +1,14 @@
+﻿namespace NServiceBus
+{
+    public partial class BridgeConfiguration
+    {
+        /// <summary>
+        /// Enable ReplyTo address translation on the bridge, which allows seamless retry of messages when endpoints move from one side of the bridge to another
+        /// </summary>
+        [ObsoleteEx(
+        Message = "The bridge now translates ReplyTo addresses for failed messages by default. To opt out, use DoNotTranslateReplyToAddressForFailedMessages",
+        RemoveInVersion = "5.0",
+        TreatAsErrorFromVersion = "4.0")]
+        public void TranslateReplyToAddressForFailedMessages() => translateReplyToAddressForFailedMessages = true;
+    }
+}

--- a/src/UnitTests/ApprovalFiles/APIApprovals.PublicApi.approved.txt
+++ b/src/UnitTests/ApprovalFiles/APIApprovals.PublicApi.approved.txt
@@ -9,9 +9,8 @@ namespace NServiceBus
         public void DoNotEnforceBestPractices() { }
         public void DoNotTranslateReplyToAddressForFailedMessages() { }
         public void RunInReceiveOnlyTransactionMode() { }
-        [System.Obsolete("The bridge now translates ReplyTo addresses for failed messages by default. To op" +
-            "t out, use DoNotTranslateReplyToAddressForFailedMessages. Will be removed in ver" +
-            "sion 5.0.0.", true)]
+        [System.Obsolete("The bridge now translates ReplyTo addresses for failed messages by default so thi" +
+            "s method call is no longer necessary. Will be removed in version 5.0.0.", true)]
         public void TranslateReplyToAddressForFailedMessages() { }
     }
     public class BridgeEndpoint

--- a/src/UnitTests/ApprovalFiles/APIApprovals.PublicApi.approved.txt
+++ b/src/UnitTests/ApprovalFiles/APIApprovals.PublicApi.approved.txt
@@ -7,7 +7,11 @@ namespace NServiceBus
         public BridgeConfiguration() { }
         public void AddTransport(NServiceBus.BridgeTransport transportConfiguration) { }
         public void DoNotEnforceBestPractices() { }
+        public void DoNotTranslateReplyToAddressForFailedMessages() { }
         public void RunInReceiveOnlyTransactionMode() { }
+        [System.Obsolete("The bridge now translates ReplyTo addresses for failed messages by default. To op" +
+            "t out, use DoNotTranslateReplyToAddressForFailedMessages. Will be removed in ver" +
+            "sion 5.0.0.", true)]
         public void TranslateReplyToAddressForFailedMessages() { }
     }
     public class BridgeEndpoint


### PR DESCRIPTION
The released fix for https://github.com/Particular/NServiceBus.MessagingBridge/issues/480 was an opt in behavior.
That is now being changed to the default behavior with an option to opt out by using `DoNotTranslateReplyToAddressForFailedMessages` as per https://github.com/Particular/NServiceBus.MessagingBridge/issues/516
