### PR TITLE
Fix EndpointRegistry proxy creation log message

### DIFF
--- a/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
+++ b/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
@@ -78,7 +78,7 @@ class EndpointRegistry(EndpointProxyFactory endpointProxyFactory, ILogger<Starta
             var startableEndpointProxy = await endpointProxyFactory.CreateProxy(targetEndpoint, proxyTransport, cancellationToken)
                 .ConfigureAwait(false);
 
-            logger.LogInformation("Proxy for endpoint {endpoint} created on {transport}", targetTransport.Name, proxyTransport.Name);
+            logger.LogInformation("Proxy for endpoint {endpoint} created on {transport}", targetEndpoint.Name, proxyTransport.Name);
 
             proxyRegistrations.Add(new ProxyRegistration
             {


### PR DESCRIPTION
FIxes #641 

Hi!
I found that the proxy creation log message contains the transport name instead of the endpoint name, so if there is more than one endpoint in the transport, the same log messages are shown, for example:

Proxy for endpoint **sql** created on **rabbit-mq**
Proxy for endpoint **sql** created on **rabbit-mq**

I suggest a slight change to the log message to show messages like this:

Proxy for endpoint **EndpointA** created on **rabbit-mq**
Proxy for endpoint **EndpointB** created on **rabbit-mq**