### PR TITLE
set FaultsHeaderKeys.FailedQ header in RawEndpointErrorHandlingPolicy

### DIFF
--- a/src/NServiceBus.MessagingBridge/RawEndpoints/RawEndpointErrorHandlingPolicy.cs
+++ b/src/NServiceBus.MessagingBridge/RawEndpoints/RawEndpointErrorHandlingPolicy.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.Raw
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using NServiceBus.Faults;
     using NServiceBus.Routing;
     using NServiceBus.Transport;
 
@@ -30,6 +31,7 @@ namespace NServiceBus.Raw
             headers.Remove(Headers.ImmediateRetries);
 
             headers[BridgeHeaders.FailedQ] = localAddress;
+            headers[FaultsHeaderKeys.FailedQ] = localAddress;
             ExceptionHeaderHelper.SetExceptionHeaders(headers, errorContext.Exception);
 
             var transportOperations = new TransportOperations(new TransportOperation(outgoingMessage, new UnicastAddressTag(errorQueue)));


### PR DESCRIPTION
We have a bridge set up between SqlServer transport and RabbitMQ transport, like SqlServer  -> RabbitMQ.
Sometimes there are problems connecting to RabbitMQ transport and the bridge sends messages to the error queue in SqlServer transport.

According to the [documentation](https://docs.particular.net/nservicebus/bridge/configuration#recoverability-error-queue), the NServiceBus.FailedQ header must be set for messages in the error queue for the ServiceControl to work correctly.

In fact, this header is missing and the ServiceControl throws the following error:
```
Error while attempting to re-import failed error message 364B8EFA-5DF1-4ECE-B815-0C71AE8B90D8.
System.Exception: Missing 'NServiceBus.FailedQ' header. Message is poison message or incorrectly send to (error) queue.
```

I suggest explicitly setting this header in the RawEndpointErrorHandlingPolicy.
This is how it was done before [this commit](https://github.com/Particular/NServiceBus.MessagingBridge/commit/58d59837ec9344ce35b527b1b587491a3300119f).