### PR TITLE
Use context.HasNativePubSubSupport instead of transport definition to rely less on that shared state

### DIFF
--- a/src/AcceptanceTests.Msmq/Address_with_machinename.cs
+++ b/src/AcceptanceTests.Msmq/Address_with_machinename.cs
@@ -11,9 +11,6 @@ public class Address_with_machinename : BridgeAcceptanceTest
     public async Task Should_get_the_message()
     {
         var ctx = await Scenario.Define<Context>()
-            .WithEndpoint<SendingEndpoint>(c => c
-                .When(cc => cc.EndpointsStarted, (b, _) => b.Send(new MyMessage())))
-            .WithEndpoint<ReceivingEndpoint>()
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -30,6 +27,9 @@ public class Address_with_machinename : BridgeAcceptanceTest
 
                 bridgeConfiguration.AddTestTransportEndpoint<SendingEndpoint>();
             })
+            .WithEndpoint<SendingEndpoint>(c => c
+                .When(cc => cc.EndpointsStarted, (b, _) => b.Send(new MyMessage())))
+            .WithEndpoint<ReceivingEndpoint>()
             .Done(c => c.ReceivingEndpointGotMessage)
             .Run();
 

--- a/src/AcceptanceTests.Msmq/Publishing_custom_address.cs
+++ b/src/AcceptanceTests.Msmq/Publishing_custom_address.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting;
+using NServiceBus.Features;
 using NUnit.Framework;
 using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
 
@@ -10,10 +11,6 @@ class Publishing_custom_address : BridgeAcceptanceTest
     public async Task Subscriber_should_get_the_event()
     {
         var context = await Scenario.Define<Context>()
-            .WithEndpoint<LogicalPublisher>()
-            .WithEndpoint<Publisher>(b => b
-                .When(c => c.SubscriberSubscribed, (session, _) => session.Publish(new MyEvent())))
-            .WithEndpoint<Subscriber>()
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -31,6 +28,16 @@ class Publishing_custom_address : BridgeAcceptanceTest
                 subscriberEndpoint.RegisterPublisher<MyEvent>(Conventions.EndpointNamingConvention(typeof(LogicalPublisher)));
                 bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
             })
+            .WithEndpoint<LogicalPublisher>()
+            .WithEndpoint<Publisher>(b => b.When(c => c.SubscriberSubscribed, (session, _) => session.Publish(new MyEvent())))
+            .WithEndpoint<Subscriber>(b => b.When(async (session, c) =>
+            {
+                await session.Subscribe<MyEvent>();
+                if (c.HasNativePubSubSupport)
+                {
+                    c.SubscriberSubscribed = true;
+                }
+            }))
             .Done(c => c.SubscriberGotEvent)
             .Run();
 
@@ -47,7 +54,14 @@ class Publishing_custom_address : BridgeAcceptanceTest
     {
         public Publisher() =>
             EndpointSetup<DefaultPublisher>(
-                c => c.OnEndpointSubscribed<Context>((_, ctx) => ctx.SubscriberSubscribed = true),
+                b => b.OnEndpointSubscribed<Context>((s, ctx) =>
+                {
+                    var subscriber = Conventions.EndpointNamingConvention(typeof(Subscriber));
+                    if (s.SubscriberEndpoint.Contains(subscriber))
+                    {
+                        ctx.SubscriberSubscribed = true;
+                    }
+                }),
                 metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
     }
 
@@ -58,7 +72,7 @@ class Publishing_custom_address : BridgeAcceptanceTest
 
     class Subscriber : EndpointConfigurationBuilder
     {
-        public Subscriber() => EndpointSetup<DefaultTestServer>(_ => { }, metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
+        public Subscriber() => EndpointSetup<DefaultTestServer>(b => b.DisableFeature<AutoSubscribe>(), metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
 
         public class MessageHandler(Context context) : IHandleMessages<MyEvent>
         {

--- a/src/AcceptanceTests.Msmq/Publishing_custom_address.cs
+++ b/src/AcceptanceTests.Msmq/Publishing_custom_address.cs
@@ -29,7 +29,7 @@ class Publishing_custom_address : BridgeAcceptanceTest
             })
             .WithEndpoint<LogicalPublisher>()
             .WithEndpoint<Publisher>(b => b
-                .When(c => c.SubscriberSubscribed, (session, c) => session.Publish(new MyEvent())))
+                .When(c => c.SubscriberSubscribed, (session, _) => session.Publish(new MyEvent())))
             .WithEndpoint<Subscriber>()
             .Done(c => c.SubscriberGotEvent)
             .Run();
@@ -46,13 +46,9 @@ class Publishing_custom_address : BridgeAcceptanceTest
     class Publisher : EndpointConfigurationBuilder
     {
         public Publisher() =>
-            EndpointSetup<DefaultPublisher>(c =>
-            {
-                c.OnEndpointSubscribed<Context>((_, ctx) =>
-                {
-                    ctx.SubscriberSubscribed = true;
-                });
-            }, metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
+            EndpointSetup<DefaultPublisher>(
+                c => c.OnEndpointSubscribed<Context>((_, ctx) => ctx.SubscriberSubscribed = true),
+                metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
     }
 
     class LogicalPublisher : EndpointConfigurationBuilder

--- a/src/AcceptanceTests.Msmq/Publishing_custom_address.cs
+++ b/src/AcceptanceTests.Msmq/Publishing_custom_address.cs
@@ -10,6 +10,10 @@ class Publishing_custom_address : BridgeAcceptanceTest
     public async Task Subscriber_should_get_the_event()
     {
         var context = await Scenario.Define<Context>()
+            .WithEndpoint<LogicalPublisher>()
+            .WithEndpoint<Publisher>(b => b
+                .When(c => c.SubscriberSubscribed, (session, _) => session.Publish(new MyEvent())))
+            .WithEndpoint<Subscriber>()
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -27,10 +31,6 @@ class Publishing_custom_address : BridgeAcceptanceTest
                 subscriberEndpoint.RegisterPublisher<MyEvent>(Conventions.EndpointNamingConvention(typeof(LogicalPublisher)));
                 bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
             })
-            .WithEndpoint<LogicalPublisher>()
-            .WithEndpoint<Publisher>(b => b
-                .When(c => c.SubscriberSubscribed, (session, _) => session.Publish(new MyEvent())))
-            .WithEndpoint<Subscriber>()
             .Done(c => c.SubscriberGotEvent)
             .Run();
 

--- a/src/AcceptanceTests/Shared/Audit.cs
+++ b/src/AcceptanceTests/Shared/Audit.cs
@@ -12,9 +12,9 @@ public class Audit : BridgeAcceptanceTest
     [Test]
     public async Task Should_forward_audit_messages_by_not_modify_message()
     {
-        var ctx = await Scenario.Define<Context>()
+        var context = await Scenario.Define<Context>()
             .WithEndpoint<PublishingEndpoint>(b => b
-                .When(c => c.HasNativePubSubSupport || c.SubscriberSubscribed, (session, _) => session.Publish(new MessageToBeAudited())))
+                .When(ctx => ctx.HasNativePubSubSupport || ctx.SubscriberSubscribed, (session, _) => session.Publish(new MessageToBeAudited())))
             .WithEndpoint<ProcessingEndpoint>()
             .WithEndpoint<AuditSpy>()
             .WithBridge(bridgeConfiguration =>
@@ -33,10 +33,10 @@ public class Audit : BridgeAcceptanceTest
             .Done(c => c.MessageAudited)
             .Run();
 
-        Assert.That(ctx.MessageAudited, Is.True);
-        foreach (var header in ctx.AuditMessageHeaders)
+        Assert.That(context.MessageAudited, Is.True);
+        foreach (var header in context.AuditMessageHeaders)
         {
-            if (ctx.ReceivedMessageHeaders.TryGetValue(header.Key, out var receivedHeaderValue))
+            if (context.ReceivedMessageHeaders.TryGetValue(header.Key, out var receivedHeaderValue))
             {
                 Assert.That(receivedHeaderValue, Is.EqualTo(header.Value),
                     $"{header.Key} is not the same on processed message and audit message.");

--- a/src/AcceptanceTests/Shared/Error.cs
+++ b/src/AcceptanceTests/Shared/Error.cs
@@ -13,9 +13,9 @@ public class Error : BridgeAcceptanceTest
     [Test]
     public async Task Should_forward_error_messages_and_not_modify_header_other_than_ReplyToAddress()
     {
-        var ctx = await Scenario.Define<Context>()
+        var context = await Scenario.Define<Context>()
             .WithEndpoint<PublishingEndpoint>(b => b
-                .When(c => c.HasNativePubSubSupport || c.SubscriberSubscribed, (session, _) => session.Publish(new FaultyMessage())))
+                .When(ctx => ctx.HasNativePubSubSupport || ctx.SubscriberSubscribed, (session, _) => session.Publish(new FaultyMessage())))
             .WithEndpoint<ProcessingEndpoint>(builder => builder.DoNotFailOnErrorMessages())
             .WithEndpoint<ErrorSpy>()
             .WithBridge(bridgeConfiguration =>
@@ -35,12 +35,12 @@ public class Error : BridgeAcceptanceTest
             .Done(c => c.MessageFailed)
             .Run();
 
-        Assert.That(ctx.MessageFailed, Is.True);
-        foreach (var header in ctx.FailedMessageHeaders)
+        Assert.That(context.MessageFailed, Is.True);
+        foreach (var header in context.FailedMessageHeaders)
         {
             if (header.Key != Headers.ReplyToAddress)
             {
-                if (ctx.ReceivedMessageHeaders.TryGetValue(header.Key, out var receivedHeaderValue))
+                if (context.ReceivedMessageHeaders.TryGetValue(header.Key, out var receivedHeaderValue))
                 {
                     Assert.That(receivedHeaderValue, Is.EqualTo(header.Value),
                         $"{header.Key} is not the same on processed message and error message.");

--- a/src/AcceptanceTests/Shared/MultipleLogicalPublishersForSameEvent.cs
+++ b/src/AcceptanceTests/Shared/MultipleLogicalPublishersForSameEvent.cs
@@ -30,11 +30,11 @@ class MultipleLogicalPublishersForSameEvent : BridgeAcceptanceTest
                 bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
             })
             .WithEndpoint<PublisherOne>(b => b
-                .When(c => c.HasNativePubSubSupport || c.SubscriberPublisherOneSubscribed,
+                .When(ctx => ctx.HasNativePubSubSupport || ctx.SubscriberPublisherOneSubscribed,
                     (session, _) => session.Publish(new MyEvent())))
             .WithEndpoint<PublisherTwo>(b => b
-                .When(c => c.HasNativePubSubSupport || c.SubscriberPublisherTwoSubscribed,
-                    (session, c) => session.Publish(new MyEvent())))
+                .When(ctx => ctx.HasNativePubSubSupport || ctx.SubscriberPublisherTwoSubscribed,
+                    (session, _) => session.Publish(new MyEvent())))
             .WithEndpoint<Subscriber>()
             .Done(c => c.SubscriberGotEventFromPublisherOne && c.SubscriberGotEventFromPublisherTwo)
             .Run();

--- a/src/AcceptanceTests/Shared/MultipleLogicalPublishersForSameEvent.cs
+++ b/src/AcceptanceTests/Shared/MultipleLogicalPublishersForSameEvent.cs
@@ -11,6 +11,13 @@ class MultipleLogicalPublishersForSameEvent : BridgeAcceptanceTest
     public async Task Subscriber_should_get_the_event()
     {
         var context = await Scenario.Define<Context>()
+            .WithEndpoint<PublisherOne>(b => b
+                .When(ctx => ctx.HasNativePubSubSupport || ctx.SubscriberPublisherOneSubscribed,
+                    (session, _) => session.Publish(new MyEvent())))
+            .WithEndpoint<PublisherTwo>(b => b
+                .When(ctx => ctx.HasNativePubSubSupport || ctx.SubscriberPublisherTwoSubscribed,
+                    (session, _) => session.Publish(new MyEvent())))
+            .WithEndpoint<Subscriber>()
             .WithBridge(bridgeConfiguration =>
             {
                 bridgeConfiguration.DoNotEnforceBestPractices();
@@ -29,13 +36,6 @@ class MultipleLogicalPublishersForSameEvent : BridgeAcceptanceTest
                     Conventions.EndpointNamingConvention(typeof(PublisherTwo)));
                 bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
             })
-            .WithEndpoint<PublisherOne>(b => b
-                .When(ctx => ctx.HasNativePubSubSupport || ctx.SubscriberPublisherOneSubscribed,
-                    (session, _) => session.Publish(new MyEvent())))
-            .WithEndpoint<PublisherTwo>(b => b
-                .When(ctx => ctx.HasNativePubSubSupport || ctx.SubscriberPublisherTwoSubscribed,
-                    (session, _) => session.Publish(new MyEvent())))
-            .WithEndpoint<Subscriber>()
             .Done(c => c.SubscriberGotEventFromPublisherOne && c.SubscriberGotEventFromPublisherTwo)
             .Run();
     }

--- a/src/AcceptanceTests/Shared/Publishing.cs
+++ b/src/AcceptanceTests/Shared/Publishing.cs
@@ -23,7 +23,7 @@ class Publishing : BridgeAcceptanceTest
                 bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
             })
             .WithEndpoint<Publisher>(b => b
-                .When(c => TransportBeingTested.SupportsPublishSubscribe || c.SubscriberSubscribed, (session, _) =>
+                .When(c => c.HasNativePubSubSupport || c.SubscriberSubscribed, (session, _) =>
                     session.Publish(new MyEvent())))
             .WithEndpoint<Subscriber>()
             .Done(c => c.SubscriberGotEvent)
@@ -41,13 +41,9 @@ class Publishing : BridgeAcceptanceTest
     class Publisher : EndpointConfigurationBuilder
     {
         public Publisher() =>
-            EndpointSetup<DefaultPublisher>(c =>
-            {
-                c.OnEndpointSubscribed<Context>((_, ctx) =>
-                {
-                    ctx.SubscriberSubscribed = true;
-                });
-            }, metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
+            EndpointSetup<DefaultPublisher>(
+                c => c.OnEndpointSubscribed<Context>((_, ctx) => ctx.SubscriberSubscribed = true),
+                metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
     }
 
     class Subscriber : EndpointConfigurationBuilder

--- a/src/AcceptanceTests/Shared/Publishing.cs
+++ b/src/AcceptanceTests/Shared/Publishing.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting;
+using NServiceBus.Features;
 using NUnit.Framework;
 using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
 
@@ -11,10 +12,6 @@ class Publishing : BridgeAcceptanceTest
     public async Task Subscriber_should_get_the_event()
     {
         var context = await Scenario.Define<Context>()
-            .WithEndpoint<Publisher>(b => b
-                .When(ctx => ctx.HasNativePubSubSupport || ctx.SubscriberSubscribed, (session, _) =>
-                    session.Publish(new MyEvent())))
-            .WithEndpoint<Subscriber>()
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -27,6 +24,15 @@ class Publishing : BridgeAcceptanceTest
                 subscriberEndpoint.RegisterPublisher<MyEvent>(Conventions.EndpointNamingConvention(typeof(Publisher)));
                 bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
             })
+            .WithEndpoint<Publisher>(b => b.When(ctx => ctx.SubscriberSubscribed, (session, _) => session.Publish(new MyEvent())))
+            .WithEndpoint<Subscriber>(b => b.When(async (session, c) =>
+            {
+                await session.Subscribe<MyEvent>();
+                if (c.HasNativePubSubSupport)
+                {
+                    c.SubscriberSubscribed = true;
+                }
+            }))
             .Done(c => c.SubscriberGotEvent)
             .Run();
 
@@ -43,13 +49,20 @@ class Publishing : BridgeAcceptanceTest
     {
         public Publisher() =>
             EndpointSetup<DefaultPublisher>(
-                c => c.OnEndpointSubscribed<Context>((_, ctx) => ctx.SubscriberSubscribed = true),
+                b => b.OnEndpointSubscribed<Context>((s, ctx) =>
+                {
+                    var subscriber = Conventions.EndpointNamingConvention(typeof(Subscriber));
+                    if (s.SubscriberEndpoint.Contains(subscriber))
+                    {
+                        ctx.SubscriberSubscribed = true;
+                    }
+                }),
                 metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
     }
 
     class Subscriber : EndpointConfigurationBuilder
     {
-        public Subscriber() => EndpointSetup<DefaultTestServer>(_ => { }, metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
+        public Subscriber() => EndpointSetup<DefaultTestServer>(b => b.DisableFeature<AutoSubscribe>(), metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
 
         public class MessageHandler(Context context) : IHandleMessages<MyEvent>
         {

--- a/src/AcceptanceTests/Shared/Publishing.cs
+++ b/src/AcceptanceTests/Shared/Publishing.cs
@@ -23,7 +23,7 @@ class Publishing : BridgeAcceptanceTest
                 bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
             })
             .WithEndpoint<Publisher>(b => b
-                .When(c => c.HasNativePubSubSupport || c.SubscriberSubscribed, (session, _) =>
+                .When(ctx => ctx.HasNativePubSubSupport || ctx.SubscriberSubscribed, (session, _) =>
                     session.Publish(new MyEvent())))
             .WithEndpoint<Subscriber>()
             .Done(c => c.SubscriberGotEvent)

--- a/src/AcceptanceTests/Shared/Publishing.cs
+++ b/src/AcceptanceTests/Shared/Publishing.cs
@@ -28,7 +28,7 @@ class Publishing : BridgeAcceptanceTest
                 bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
             })
             .Done(c => c.SubscriberGotEvent)
-            .Run(TimeSpan.FromSeconds(5));
+            .Run();
 
         Assert.That(context.SubscriberGotEvent, Is.True);
     }

--- a/src/AcceptanceTests/Shared/ReplyToAddress.cs
+++ b/src/AcceptanceTests/Shared/ReplyToAddress.cs
@@ -11,18 +11,15 @@ public class ReplyToAddress : BridgeAcceptanceTest
     [Test]
     public async Task Should_translate_address_for_already_migrated_endpoint()
     {
-        var ctx = await Scenario.Define<Context>()
-            .WithEndpoint<SendingEndpoint>(builder =>
-            {
-                builder.DoNotFailOnErrorMessages();
-                builder.When(c => c.EndpointsStarted, (session, _) =>
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<SendingEndpoint>(b => b.When(ctx => ctx.EndpointsStarted,
+                (session, _) =>
                 {
                     var options = new SendOptions();
                     options.SetDestination(Conventions.EndpointNamingConvention(typeof(SecondMigratedEndpoint)));
 
                     return session.Send(new ADelayedMessage(), options);
-                });
-            })
+                }).DoNotFailOnErrorMessages())
             .WithEndpoint<FirstMigratedEndpoint>()
             .WithEndpoint<SecondMigratedEndpoint>()
             .WithBridge(bridgeConfiguration =>

--- a/src/AcceptanceTests/Shared/ReplyToAddress.cs
+++ b/src/AcceptanceTests/Shared/ReplyToAddress.cs
@@ -12,16 +12,6 @@ public class ReplyToAddress : BridgeAcceptanceTest
     public async Task Should_translate_address_for_already_migrated_endpoint()
     {
         var context = await Scenario.Define<Context>()
-            .WithEndpoint<SendingEndpoint>(b => b.When(ctx => ctx.EndpointsStarted,
-                (session, _) =>
-                {
-                    var options = new SendOptions();
-                    options.SetDestination(Conventions.EndpointNamingConvention(typeof(SecondMigratedEndpoint)));
-
-                    return session.Send(new ADelayedMessage(), options);
-                }).DoNotFailOnErrorMessages())
-            .WithEndpoint<FirstMigratedEndpoint>()
-            .WithEndpoint<SecondMigratedEndpoint>()
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(DefaultTestServer.GetTestTransportDefinition())
@@ -36,6 +26,16 @@ public class ReplyToAddress : BridgeAcceptanceTest
                 theOtherTransport.AddTestEndpoint<SecondMigratedEndpoint>();
                 bridgeConfiguration.AddTransport(theOtherTransport);
             })
+            .WithEndpoint<SendingEndpoint>(b => b.When(ctx => ctx.EndpointsStarted,
+                (session, _) =>
+                {
+                    var options = new SendOptions();
+                    options.SetDestination(Conventions.EndpointNamingConvention(typeof(SecondMigratedEndpoint)));
+
+                    return session.Send(new ADelayedMessage(), options);
+                }).DoNotFailOnErrorMessages())
+            .WithEndpoint<FirstMigratedEndpoint>()
+            .WithEndpoint<SecondMigratedEndpoint>()
             .Done(c => c.ADelayedMessageReceived)
             .Run();
 

--- a/src/AcceptanceTests/Shared/Request_reply.cs
+++ b/src/AcceptanceTests/Shared/Request_reply.cs
@@ -10,9 +10,6 @@ public class Request_reply : BridgeAcceptanceTest
     public async Task Should_get_the_reply()
     {
         var ctx = await Scenario.Define<Context>()
-            .WithEndpoint<SendingEndpoint>(b => b
-                .When(ctx => ctx.EndpointsStarted, (session, _) => session.Send(new MyMessage())))
-            .WithEndpoint<ReplyingEndpoint>()
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -21,6 +18,8 @@ public class Request_reply : BridgeAcceptanceTest
 
                 bridgeConfiguration.AddTestTransportEndpoint<ReplyingEndpoint>();
             })
+            .WithEndpoint<SendingEndpoint>(b => b.When(ctx => ctx.EndpointsStarted, (session, _) => session.Send(new MyMessage())))
+            .WithEndpoint<ReplyingEndpoint>()
             .Done(c => c.SendingEndpointGotResponse)
             .Run();
 

--- a/src/AcceptanceTests/Shared/Request_reply.cs
+++ b/src/AcceptanceTests/Shared/Request_reply.cs
@@ -10,19 +10,19 @@ public class Request_reply : BridgeAcceptanceTest
     public async Task Should_get_the_reply()
     {
         var ctx = await Scenario.Define<Context>()
-                    .WithEndpoint<SendingEndpoint>(c => c
-                        .When(cc => cc.EndpointsStarted, (b, _) => b.Send(new MyMessage())))
-                    .WithEndpoint<ReplyingEndpoint>()
-                    .WithBridge(bridgeConfiguration =>
-                    {
-                        var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
-                        bridgeTransport.AddTestEndpoint<SendingEndpoint>();
-                        bridgeConfiguration.AddTransport(bridgeTransport);
+            .WithEndpoint<SendingEndpoint>(b => b
+                .When(ctx => ctx.EndpointsStarted, (session, _) => session.Send(new MyMessage())))
+            .WithEndpoint<ReplyingEndpoint>()
+            .WithBridge(bridgeConfiguration =>
+            {
+                var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
+                bridgeTransport.AddTestEndpoint<SendingEndpoint>();
+                bridgeConfiguration.AddTransport(bridgeTransport);
 
-                        bridgeConfiguration.AddTestTransportEndpoint<ReplyingEndpoint>();
-                    })
-                    .Done(c => c.SendingEndpointGotResponse)
-                    .Run();
+                bridgeConfiguration.AddTestTransportEndpoint<ReplyingEndpoint>();
+            })
+            .Done(c => c.SendingEndpointGotResponse)
+            .Run();
 
         Assert.That(ctx.SendingEndpointGotResponse, Is.True);
     }

--- a/src/AcceptanceTests/Shared/Request_reply_custom_address.cs
+++ b/src/AcceptanceTests/Shared/Request_reply_custom_address.cs
@@ -39,13 +39,11 @@ public class Request_reply_custom_address : BridgeAcceptanceTest
 
     public class SendingEndpoint : EndpointConfigurationBuilder
     {
-        public SendingEndpoint()
-        {
+        public SendingEndpoint() =>
             EndpointSetup<DefaultServer>(c =>
             {
                 c.ConfigureRouting().RouteToEndpoint(typeof(MyMessage), typeof(ReplyingEndpoint));
             });
-        }
 
         public class ResponseHandler(ITransportAddressResolver transportAddressResolver) : IHandleMessages<StartMessage>
         {

--- a/src/AcceptanceTests/Shared/Request_reply_custom_address.cs
+++ b/src/AcceptanceTests/Shared/Request_reply_custom_address.cs
@@ -11,10 +11,6 @@ public class Request_reply_custom_address : BridgeAcceptanceTest
     public async Task Should_get_the_reply()
     {
         var ctx = await Scenario.Define<Context>()
-            .WithEndpoint<SendingEndpoint>(b => b
-                .When(ctx => ctx.EndpointsStarted, (session, _) => session.SendLocal(new StartMessage())))
-            .WithEndpoint<ReplyingEndpoint>()
-            .WithEndpoint<ReplyReceivingEndpoint>()
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -26,6 +22,9 @@ public class Request_reply_custom_address : BridgeAcceptanceTest
 
                 bridgeConfiguration.AddTestTransportEndpoint<ReplyingEndpoint>();
             })
+            .WithEndpoint<SendingEndpoint>(b => b.When(ctx => ctx.EndpointsStarted, (session, _) => session.SendLocal(new StartMessage())))
+            .WithEndpoint<ReplyingEndpoint>()
+            .WithEndpoint<ReplyReceivingEndpoint>()
             .Done(c => c.SendingEndpointGotResponse)
             .Run();
 

--- a/src/AcceptanceTests/Shared/Request_reply_custom_address.cs
+++ b/src/AcceptanceTests/Shared/Request_reply_custom_address.cs
@@ -11,23 +11,23 @@ public class Request_reply_custom_address : BridgeAcceptanceTest
     public async Task Should_get_the_reply()
     {
         var ctx = await Scenario.Define<Context>()
-                    .WithEndpoint<SendingEndpoint>(c => c
-                        .When(cc => cc.EndpointsStarted, (b, _) => b.SendLocal(new StartMessage())))
-                    .WithEndpoint<ReplyingEndpoint>()
-                    .WithEndpoint<ReplyReceivingEndpoint>()
-                    .WithBridge(bridgeConfiguration =>
-                    {
-                        var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
+            .WithEndpoint<SendingEndpoint>(b => b
+                .When(ctx => ctx.EndpointsStarted, (session, _) => session.SendLocal(new StartMessage())))
+            .WithEndpoint<ReplyingEndpoint>()
+            .WithEndpoint<ReplyReceivingEndpoint>()
+            .WithBridge(bridgeConfiguration =>
+            {
+                var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
 
-                        bridgeTransport.AddTestEndpoint<SendingEndpoint>();
-                        bridgeTransport.AddTestEndpoint<ReplyReceivingEndpoint>();
+                bridgeTransport.AddTestEndpoint<SendingEndpoint>();
+                bridgeTransport.AddTestEndpoint<ReplyReceivingEndpoint>();
 
-                        bridgeConfiguration.AddTransport(bridgeTransport);
+                bridgeConfiguration.AddTransport(bridgeTransport);
 
-                        bridgeConfiguration.AddTestTransportEndpoint<ReplyingEndpoint>();
-                    })
-                    .Done(c => c.SendingEndpointGotResponse)
-                    .Run();
+                bridgeConfiguration.AddTestTransportEndpoint<ReplyingEndpoint>();
+            })
+            .Done(c => c.SendingEndpointGotResponse)
+            .Run();
 
         Assert.That(ctx.SendingEndpointGotResponse, Is.True);
     }

--- a/src/AcceptanceTests/Shared/Retry.cs
+++ b/src/AcceptanceTests/Shared/Retry.cs
@@ -16,9 +16,6 @@ public class Retry : BridgeAcceptanceTest
     public async Task Should_work(bool doNotTranslateReplyToAdressForFailedMessages)
     {
         var context = await Scenario.Define<Context>()
-            .WithEndpoint<ProcessingEndpoint>(b => b.When(ctx => ctx.EndpointsStarted, (session, _) => session.SendLocal(new FaultyMessage()))
-                .DoNotFailOnErrorMessages())
-            .WithEndpoint<FakeSCError>()
             .WithBridge(bridgeConfiguration =>
             {
                 if (doNotTranslateReplyToAdressForFailedMessages)
@@ -36,6 +33,9 @@ public class Retry : BridgeAcceptanceTest
                 theOtherTransport.AddTestEndpoint<ProcessingEndpoint>();
                 bridgeConfiguration.AddTransport(theOtherTransport);
             })
+            .WithEndpoint<ProcessingEndpoint>(b => b.When(ctx => ctx.EndpointsStarted, (session, _) => session.SendLocal(new FaultyMessage()))
+                .DoNotFailOnErrorMessages())
+            .WithEndpoint<FakeSCError>()
             .Done(c => c.GotRetrySuccessfullAck)
             .Run();
 

--- a/src/AcceptanceTests/Shared/Send_local.cs
+++ b/src/AcceptanceTests/Shared/Send_local.cs
@@ -14,21 +14,21 @@ public class Send_local : BridgeAcceptanceTest
     [Test]
     public async Task Should_transfer_send_local_message()
     {
-        var ctx = await Scenario.Define<Context>()
-                    .WithEndpoint<OriginalEndpoint>()
-                    .WithEndpoint<MigratedEndpoint>()
-                    .WithBridge(bridgeConfiguration =>
-                    {
-                        var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
-                        bridgeTransport.HasEndpoint("_");
-                        bridgeConfiguration.AddTransport(bridgeTransport);
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<OriginalEndpoint>()
+            .WithEndpoint<MigratedEndpoint>()
+            .WithBridge(bridgeConfiguration =>
+            {
+                var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
+                bridgeTransport.HasEndpoint("_");
+                bridgeConfiguration.AddTransport(bridgeTransport);
 
-                        bridgeConfiguration.AddTestTransportEndpoint(new BridgeEndpoint(OriginalEndpointName));
-                    })
-                    .Done(c => c.MessageReceived)
-                    .Run();
+                bridgeConfiguration.AddTestTransportEndpoint(new BridgeEndpoint(OriginalEndpointName));
+            })
+            .Done(c => c.MessageReceived)
+            .Run();
 
-        Assert.That(ctx.MessageReceived, Is.True);
+        Assert.That(context.MessageReceived, Is.True);
     }
 
     public class Context : ScenarioContext

--- a/src/AcceptanceTests/Shared/Send_local.cs
+++ b/src/AcceptanceTests/Shared/Send_local.cs
@@ -15,8 +15,6 @@ public class Send_local : BridgeAcceptanceTest
     public async Task Should_transfer_send_local_message()
     {
         var context = await Scenario.Define<Context>()
-            .WithEndpoint<OriginalEndpoint>()
-            .WithEndpoint<MigratedEndpoint>()
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -25,6 +23,8 @@ public class Send_local : BridgeAcceptanceTest
 
                 bridgeConfiguration.AddTestTransportEndpoint(new BridgeEndpoint(OriginalEndpointName));
             })
+            .WithEndpoint<OriginalEndpoint>()
+            .WithEndpoint<MigratedEndpoint>()
             .Done(c => c.MessageReceived)
             .Run();
 

--- a/src/AcceptanceTests/Shared/Subscribing.cs
+++ b/src/AcceptanceTests/Shared/Subscribing.cs
@@ -12,7 +12,7 @@ class Subscribing : BridgeAcceptanceTest
         var context = await Scenario.Define<Context>()
             .WithEndpoint<Subscriber>()
             .WithEndpoint<Publisher>(b => b
-                .When(c => c.HasNativePubSubSupport || c.SubscriberSubscribed, (session, _) => session.Publish(new MyEvent())))
+                .When(ctx => ctx.HasNativePubSubSupport || ctx.SubscriberSubscribed, (session, _) => session.Publish(new MyEvent())))
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);

--- a/src/AcceptanceTests/Shared/Subscribing.cs
+++ b/src/AcceptanceTests/Shared/Subscribing.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting;
+using NServiceBus.Features;
 using NUnit.Framework;
 using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
 
@@ -10,9 +11,6 @@ class Subscribing : BridgeAcceptanceTest
     public async Task Should_get_the_event()
     {
         var context = await Scenario.Define<Context>()
-            .WithEndpoint<Subscriber>()
-            .WithEndpoint<Publisher>(b => b
-                .When(ctx => ctx.HasNativePubSubSupport || ctx.SubscriberSubscribed, (session, _) => session.Publish(new MyEvent())))
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -27,6 +25,15 @@ class Subscribing : BridgeAcceptanceTest
 
                 bridgeConfiguration.AddTestTransportEndpoint<Publisher>();
             })
+            .WithEndpoint<Publisher>(b => b.When(ctx => ctx.SubscriberSubscribed, (session, _) => session.Publish(new MyEvent())))
+            .WithEndpoint<Subscriber>(b => b.When(async (session, c) =>
+            {
+                await session.Subscribe<MyEvent>();
+                if (c.HasNativePubSubSupport)
+                {
+                    c.SubscriberSubscribed = true;
+                }
+            }))
             .Done(c => c.SubscriberGotEvent)
             .Run();
 
@@ -42,13 +49,20 @@ class Subscribing : BridgeAcceptanceTest
     class Publisher : EndpointConfigurationBuilder
     {
         public Publisher() => EndpointSetup<DefaultTestPublisher>(
-            c => c.OnEndpointSubscribed<Context>((_, ctx) => ctx.SubscriberSubscribed = true),
+            b => b.OnEndpointSubscribed<Context>((s, ctx) =>
+            {
+                var subscriber = Conventions.EndpointNamingConvention(typeof(Subscriber));
+                if (s.SubscriberEndpoint.Contains(subscriber))
+                {
+                    ctx.SubscriberSubscribed = true;
+                }
+            }),
             metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
     }
 
     class Subscriber : EndpointConfigurationBuilder
     {
-        public Subscriber() => EndpointSetup<DefaultServer>(_ => { }, metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
+        public Subscriber() => EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>(), metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
 
         public class MessageHandler(Context context) : IHandleMessages<MyEvent>
         {

--- a/src/AcceptanceTests/Shared/Subscribing.cs
+++ b/src/AcceptanceTests/Shared/Subscribing.cs
@@ -12,7 +12,7 @@ class Subscribing : BridgeAcceptanceTest
         var context = await Scenario.Define<Context>()
             .WithEndpoint<Subscriber>()
             .WithEndpoint<Publisher>(b => b
-                .When((session, _) => session.Publish(new MyEvent())))
+                .When(c => c.HasNativePubSubSupport || c.SubscriberSubscribed, (session, _) => session.Publish(new MyEvent())))
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -41,7 +41,9 @@ class Subscribing : BridgeAcceptanceTest
 
     class Publisher : EndpointConfigurationBuilder
     {
-        public Publisher() => EndpointSetup<DefaultTestPublisher>(_ => { }, metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
+        public Publisher() => EndpointSetup<DefaultTestPublisher>(
+            c => c.OnEndpointSubscribed<Context>((_, ctx) => ctx.SubscriberSubscribed = true),
+            metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
     }
 
     class Subscriber : EndpointConfigurationBuilder

--- a/src/AcceptanceTests/Shared/ThreeTransports.cs
+++ b/src/AcceptanceTests/Shared/ThreeTransports.cs
@@ -15,12 +15,12 @@ public class ThreeTransports : BridgeAcceptanceTest
         var options = new SendOptions();
         options.SetDestination(Conventions.EndpointNamingConvention(typeof(ReceivingEndpoint)));
 
-        var ctx = await Scenario.Define<Context>()
+        var context = await Scenario.Define<Context>()
             .WithEndpoint<ReceivingEndpoint>()
-            .WithEndpoint<EndpointOnTestingTransport>(builder => builder
-                .When(c => c.EndpointsStarted, (session, _) => session.Send(new SomeMessage { From = endpointOnTestingTransportName }, options)))
-            .WithEndpoint<EndpointOnTransportUnderTest>(builder => builder
-                .When(c => c.EndpointsStarted, (session, _) => session.Send(new SomeMessage { From = endpointOnTransportUnderTestName }, options)))
+            .WithEndpoint<EndpointOnTestingTransport>(b => b
+                .When(ctx => ctx.EndpointsStarted, (session, _) => session.Send(new SomeMessage { From = endpointOnTestingTransportName }, options)))
+            .WithEndpoint<EndpointOnTransportUnderTest>(b => b
+                .When(ctx => ctx.EndpointsStarted, (session, _) => session.Send(new SomeMessage { From = endpointOnTransportUnderTestName }, options)))
             .WithBridge(bridgeConfiguration =>
             {
                 var receivingTransport = new TestableBridgeTransport(ReceivingTestServer.GetReceivingTransportDefinition())
@@ -53,7 +53,7 @@ public class ThreeTransports : BridgeAcceptanceTest
     {
         public ReceivingEndpoint() => EndpointSetup<ReceivingTestServer>();
 
-        class SomeMessageHandler(Context context) : IHandleMessages<SomeMessage>
+        class SomeMessageHandler(Context testContext) : IHandleMessages<SomeMessage>
         {
             public Task Handle(SomeMessage message, IMessageHandlerContext context)
             {
@@ -67,8 +67,6 @@ public class ThreeTransports : BridgeAcceptanceTest
 
                 return Task.CompletedTask;
             }
-
-            readonly Context testContext = context;
         }
     }
 

--- a/src/AcceptanceTests/Shared/ThreeTransports.cs
+++ b/src/AcceptanceTests/Shared/ThreeTransports.cs
@@ -16,11 +16,6 @@ public class ThreeTransports : BridgeAcceptanceTest
         options.SetDestination(Conventions.EndpointNamingConvention(typeof(ReceivingEndpoint)));
 
         var context = await Scenario.Define<Context>()
-            .WithEndpoint<ReceivingEndpoint>()
-            .WithEndpoint<EndpointOnTestingTransport>(b => b
-                .When(ctx => ctx.EndpointsStarted, (session, _) => session.Send(new SomeMessage { From = endpointOnTestingTransportName }, options)))
-            .WithEndpoint<EndpointOnTransportUnderTest>(b => b
-                .When(ctx => ctx.EndpointsStarted, (session, _) => session.Send(new SomeMessage { From = endpointOnTransportUnderTestName }, options)))
             .WithBridge(bridgeConfiguration =>
             {
                 var receivingTransport = new TestableBridgeTransport(ReceivingTestServer.GetReceivingTransportDefinition())
@@ -44,6 +39,11 @@ public class ThreeTransports : BridgeAcceptanceTest
                 transportUnderTest.AddTestEndpoint<EndpointOnTransportUnderTest>();
                 bridgeConfiguration.AddTransport(transportUnderTest);
             })
+            .WithEndpoint<ReceivingEndpoint>()
+            .WithEndpoint<EndpointOnTestingTransport>(b => b
+                .When(ctx => ctx.EndpointsStarted, (session, _) => session.Send(new SomeMessage { From = endpointOnTestingTransportName }, options)))
+            .WithEndpoint<EndpointOnTransportUnderTest>(b => b
+                .When(ctx => ctx.EndpointsStarted, (session, _) => session.Send(new SomeMessage { From = endpointOnTransportUnderTestName }, options)))
             .Done(c => c.ReceivedMessageCount == 2)
             .Run();
 

--- a/src/AcceptanceTests/Shared/TransferFailureTests.cs
+++ b/src/AcceptanceTests/Shared/TransferFailureTests.cs
@@ -16,14 +16,6 @@ public class TransferFailureTests : BridgeAcceptanceTest
     public async Task Should_add_failedq_header_when_transfer_fails()
     {
         var context = await Scenario.Define<Context>()
-            .WithEndpoint<ErrorSpy>()
-            .WithEndpoint<Sender>(b => b
-                .When(ctx => ctx.EndpointsStarted, async (session, c) =>
-                {
-                    var opts = new SendOptions();
-                    opts.SetHeader(FakeShovelHeader.FailureHeader, string.Empty);
-                    await session.Send(new FaultyMessage(), opts);
-                }))
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -34,6 +26,14 @@ public class TransferFailureTests : BridgeAcceptanceTest
                 var subscriberEndpoint = new BridgeEndpoint(ReceiveDummyQueue);
                 bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
             })
+            .WithEndpoint<ErrorSpy>()
+            .WithEndpoint<Sender>(b => b
+                .When(ctx => ctx.EndpointsStarted, async (session, c) =>
+                {
+                    var opts = new SendOptions();
+                    opts.SetHeader(FakeShovelHeader.FailureHeader, string.Empty);
+                    await session.Send(new FaultyMessage(), opts);
+                }))
             .Done(c => c.MessageFailed)
             .Run();
 
@@ -50,15 +50,6 @@ public class TransferFailureTests : BridgeAcceptanceTest
     public async Task Should_add_failedq_header_when_transfer_fails_for_subsequent_failures()
     {
         var context = await Scenario.Define<Context>()
-            .WithEndpoint<ErrorSpy>()
-            .WithEndpoint<Sender>(b => b
-                .When(ctx => ctx.EndpointsStarted, async (session, _) =>
-                {
-                    var opts = new SendOptions();
-                    opts.SetHeader(FailedQHeader, ReceiveDummyQueue);
-                    opts.SetHeader(FakeShovelHeader.FailureHeader, string.Empty);
-                    await session.Send(new FaultyMessage(), opts);
-                }))
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -69,6 +60,15 @@ public class TransferFailureTests : BridgeAcceptanceTest
                 var subscriberEndpoint = new BridgeEndpoint(ReceiveDummyQueue);
                 bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
             })
+            .WithEndpoint<ErrorSpy>()
+            .WithEndpoint<Sender>(b => b
+                .When(ctx => ctx.EndpointsStarted, async (session, _) =>
+                {
+                    var opts = new SendOptions();
+                    opts.SetHeader(FailedQHeader, ReceiveDummyQueue);
+                    opts.SetHeader(FakeShovelHeader.FailureHeader, string.Empty);
+                    await session.Send(new FaultyMessage(), opts);
+                }))
             .Done(c => c.MessageFailed)
             .Run();
 

--- a/src/AcceptanceTests/Shared/TransferFailureTests.cs
+++ b/src/AcceptanceTests/Shared/TransferFailureTests.cs
@@ -84,21 +84,15 @@ public class TransferFailureTests : BridgeAcceptanceTest
     public class Sender : EndpointConfigurationBuilder
     {
         public Sender() =>
-            EndpointSetup<DefaultServer>(c =>
-            {
-                c.ConfigureRouting().RouteToEndpoint(typeof(FaultyMessage), ReceiveDummyQueue);
-            });
+            EndpointSetup<DefaultServer>(c => c.ConfigureRouting().RouteToEndpoint(typeof(FaultyMessage), ReceiveDummyQueue));
     }
 
     public class ErrorSpy : EndpointConfigurationBuilder
     {
         public ErrorSpy() =>
-            EndpointSetup<DefaultServer>(c =>
-            {
-                c.OverrideLocalAddress(ErrorQueue);
-            });
+            EndpointSetup<DefaultServer>(c => c.OverrideLocalAddress(ErrorQueue));
 
-        class FailedMessageHander(Context testContext) : IHandleMessages<FaultyMessage>
+        class FailedMessageHandler(Context testContext) : IHandleMessages<FaultyMessage>
         {
             public Task Handle(FaultyMessage message, IMessageHandlerContext context)
             {

--- a/src/AcceptanceTests/Shared/TransferFailureTests.cs
+++ b/src/AcceptanceTests/Shared/TransferFailureTests.cs
@@ -15,10 +15,10 @@ public class TransferFailureTests : BridgeAcceptanceTest
     [Test]
     public async Task Should_add_failedq_header_when_transfer_fails()
     {
-        var ctx = await Scenario.Define<Context>()
+        var context = await Scenario.Define<Context>()
             .WithEndpoint<ErrorSpy>()
             .WithEndpoint<Sender>(b => b
-                .When(c => c.EndpointsStarted, async (session, c) =>
+                .When(ctx => ctx.EndpointsStarted, async (session, c) =>
                 {
                     var opts = new SendOptions();
                     opts.SetHeader(FakeShovelHeader.FailureHeader, string.Empty);
@@ -39,8 +39,8 @@ public class TransferFailureTests : BridgeAcceptanceTest
 
         Assert.Multiple(() =>
         {
-            Assert.That(ctx.MessageFailed, Is.True, "Message did not fail");
-            Assert.That(ctx.FailedMessageHeaders.ContainsKey(FailedQHeader),
+            Assert.That(context.MessageFailed, Is.True, "Message did not fail");
+            Assert.That(context.FailedMessageHeaders.ContainsKey(FailedQHeader),
                 Is.True,
                 $"Failed message headers does not contain {FailedQHeader}");
         });
@@ -49,10 +49,10 @@ public class TransferFailureTests : BridgeAcceptanceTest
     [Test]
     public async Task Should_add_failedq_header_when_transfer_fails_for_subsequent_failures()
     {
-        var ctx = await Scenario.Define<Context>()
+        var context = await Scenario.Define<Context>()
             .WithEndpoint<ErrorSpy>()
             .WithEndpoint<Sender>(b => b
-                .When(c => c.EndpointsStarted, async (session, c) =>
+                .When(ctx => ctx.EndpointsStarted, async (session, _) =>
                 {
                     var opts = new SendOptions();
                     opts.SetHeader(FailedQHeader, ReceiveDummyQueue);
@@ -74,8 +74,8 @@ public class TransferFailureTests : BridgeAcceptanceTest
 
         Assert.Multiple(() =>
         {
-            Assert.That(ctx.MessageFailed, Is.True, "Message did not fail");
-            Assert.That(ctx.FailedMessageHeaders.ContainsKey(FailedQHeader),
+            Assert.That(context.MessageFailed, Is.True, "Message did not fail");
+            Assert.That(context.FailedMessageHeaders.ContainsKey(FailedQHeader),
                 Is.True,
                 $"Failed message headers does not contain {FailedQHeader}");
         });


### PR DESCRIPTION
Follow up on #659 

This is another small PR to rely less on the TransportBeingTested shared state where it is not necessary. This will facilitate further simplifications of the infrastructure. And if not it is still a good change ;)

The [core infrastructure sets](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs#L64)

```csharp
scenarioContext.HasNativePubSubSupport = transportDefinition.SupportsPublishSubscribe;
```