### PR TITLE
Make sure the bridge component consistently starts first in the acceptance tests

### DIFF
--- a/src/AcceptanceTests.Msmq/Address_with_machinename.cs
+++ b/src/AcceptanceTests.Msmq/Address_with_machinename.cs
@@ -11,9 +11,6 @@ public class Address_with_machinename : BridgeAcceptanceTest
     public async Task Should_get_the_message()
     {
         var ctx = await Scenario.Define<Context>()
-            .WithEndpoint<SendingEndpoint>(c => c
-                .When(cc => cc.EndpointsStarted, (b, _) => b.Send(new MyMessage())))
-            .WithEndpoint<ReceivingEndpoint>()
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -30,6 +27,9 @@ public class Address_with_machinename : BridgeAcceptanceTest
 
                 bridgeConfiguration.AddTestTransportEndpoint<SendingEndpoint>();
             })
+            .WithEndpoint<SendingEndpoint>(c => c
+                .When(cc => cc.EndpointsStarted, (b, _) => b.Send(new MyMessage())))
+            .WithEndpoint<ReceivingEndpoint>()
             .Done(c => c.ReceivingEndpointGotMessage)
             .Run();
 

--- a/src/AcceptanceTests/Shared/Audit.cs
+++ b/src/AcceptanceTests/Shared/Audit.cs
@@ -13,10 +13,6 @@ public class Audit : BridgeAcceptanceTest
     public async Task Should_forward_audit_messages_by_not_modify_message()
     {
         var ctx = await Scenario.Define<Context>()
-            .WithEndpoint<PublishingEndpoint>(b => b
-                .When(c => TransportBeingTested.SupportsPublishSubscribe || c.SubscriberSubscribed, (session, _) => session.Publish(new MessageToBeAudited())))
-            .WithEndpoint<ProcessingEndpoint>()
-            .WithEndpoint<AuditSpy>()
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -30,6 +26,10 @@ public class Audit : BridgeAcceptanceTest
                     Conventions.EndpointNamingConvention(typeof(PublishingEndpoint)));
                 bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
             })
+            .WithEndpoint<PublishingEndpoint>(b => b
+                .When(c => TransportBeingTested.SupportsPublishSubscribe || c.SubscriberSubscribed, (session, _) => session.Publish(new MessageToBeAudited())))
+            .WithEndpoint<ProcessingEndpoint>()
+            .WithEndpoint<AuditSpy>()
             .Done(c => c.MessageAudited)
             .Run();
 

--- a/src/AcceptanceTests/Shared/Error.cs
+++ b/src/AcceptanceTests/Shared/Error.cs
@@ -14,10 +14,6 @@ public class Error : BridgeAcceptanceTest
     public async Task Should_forward_error_messages_and_not_modify_header_other_than_ReplyToAddress()
     {
         var ctx = await Scenario.Define<Context>()
-            .WithEndpoint<PublishingEndpoint>(b => b
-                .When(c => TransportBeingTested.SupportsPublishSubscribe || c.SubscriberSubscribed, (session, _) => session.Publish(new FaultyMessage())))
-            .WithEndpoint<ProcessingEndpoint>(builder => builder.DoNotFailOnErrorMessages())
-            .WithEndpoint<ErrorSpy>()
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -32,6 +28,10 @@ public class Error : BridgeAcceptanceTest
                 bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
 
             })
+            .WithEndpoint<PublishingEndpoint>(b => b
+                .When(c => TransportBeingTested.SupportsPublishSubscribe || c.SubscriberSubscribed, (session, _) => session.Publish(new FaultyMessage())))
+            .WithEndpoint<ProcessingEndpoint>(builder => builder.DoNotFailOnErrorMessages())
+            .WithEndpoint<ErrorSpy>()
             .Done(c => c.MessageFailed)
             .Run();
 

--- a/src/AcceptanceTests/Shared/ReplyToAddress.cs
+++ b/src/AcceptanceTests/Shared/ReplyToAddress.cs
@@ -12,19 +12,6 @@ public class ReplyToAddress : BridgeAcceptanceTest
     public async Task Should_translate_address_for_already_migrated_endpoint()
     {
         var ctx = await Scenario.Define<Context>()
-            .WithEndpoint<SendingEndpoint>(builder =>
-            {
-                builder.DoNotFailOnErrorMessages();
-                builder.When(c => c.EndpointsStarted, (session, _) =>
-                {
-                    var options = new SendOptions();
-                    options.SetDestination(Conventions.EndpointNamingConvention(typeof(SecondMigratedEndpoint)));
-
-                    return session.Send(new ADelayedMessage(), options);
-                });
-            })
-            .WithEndpoint<FirstMigratedEndpoint>()
-            .WithEndpoint<SecondMigratedEndpoint>()
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(DefaultTestServer.GetTestTransportDefinition())
@@ -39,6 +26,19 @@ public class ReplyToAddress : BridgeAcceptanceTest
                 theOtherTransport.AddTestEndpoint<SecondMigratedEndpoint>();
                 bridgeConfiguration.AddTransport(theOtherTransport);
             })
+            .WithEndpoint<SendingEndpoint>(builder =>
+            {
+                builder.DoNotFailOnErrorMessages();
+                builder.When(c => c.EndpointsStarted, (session, _) =>
+                {
+                    var options = new SendOptions();
+                    options.SetDestination(Conventions.EndpointNamingConvention(typeof(SecondMigratedEndpoint)));
+
+                    return session.Send(new ADelayedMessage(), options);
+                });
+            })
+            .WithEndpoint<FirstMigratedEndpoint>()
+            .WithEndpoint<SecondMigratedEndpoint>()
             .Done(c => c.ADelayedMessageReceived)
             .Run();
 

--- a/src/AcceptanceTests/Shared/Request_reply.cs
+++ b/src/AcceptanceTests/Shared/Request_reply.cs
@@ -10,19 +10,19 @@ public class Request_reply : BridgeAcceptanceTest
     public async Task Should_get_the_reply()
     {
         var ctx = await Scenario.Define<Context>()
-                    .WithEndpoint<SendingEndpoint>(c => c
-                        .When(cc => cc.EndpointsStarted, (b, _) => b.Send(new MyMessage())))
-                    .WithEndpoint<ReplyingEndpoint>()
-                    .WithBridge(bridgeConfiguration =>
-                    {
-                        var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
-                        bridgeTransport.AddTestEndpoint<SendingEndpoint>();
-                        bridgeConfiguration.AddTransport(bridgeTransport);
+            .WithBridge(bridgeConfiguration =>
+            {
+                var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
+                bridgeTransport.AddTestEndpoint<SendingEndpoint>();
+                bridgeConfiguration.AddTransport(bridgeTransport);
 
-                        bridgeConfiguration.AddTestTransportEndpoint<ReplyingEndpoint>();
-                    })
-                    .Done(c => c.SendingEndpointGotResponse)
-                    .Run();
+                bridgeConfiguration.AddTestTransportEndpoint<ReplyingEndpoint>();
+            })
+            .WithEndpoint<SendingEndpoint>(c => c
+                .When(cc => cc.EndpointsStarted, (b, _) => b.Send(new MyMessage())))
+            .WithEndpoint<ReplyingEndpoint>()
+            .Done(c => c.SendingEndpointGotResponse)
+            .Run();
 
         Assert.That(ctx.SendingEndpointGotResponse, Is.True);
     }

--- a/src/AcceptanceTests/Shared/Request_reply_custom_address.cs
+++ b/src/AcceptanceTests/Shared/Request_reply_custom_address.cs
@@ -11,23 +11,23 @@ public class Request_reply_custom_address : BridgeAcceptanceTest
     public async Task Should_get_the_reply()
     {
         var ctx = await Scenario.Define<Context>()
-                    .WithEndpoint<SendingEndpoint>(c => c
-                        .When(cc => cc.EndpointsStarted, (b, _) => b.SendLocal(new StartMessage())))
-                    .WithEndpoint<ReplyingEndpoint>()
-                    .WithEndpoint<ReplyReceivingEndpoint>()
-                    .WithBridge(bridgeConfiguration =>
-                    {
-                        var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
+            .WithBridge(bridgeConfiguration =>
+            {
+                var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
 
-                        bridgeTransport.AddTestEndpoint<SendingEndpoint>();
-                        bridgeTransport.AddTestEndpoint<ReplyReceivingEndpoint>();
+                bridgeTransport.AddTestEndpoint<SendingEndpoint>();
+                bridgeTransport.AddTestEndpoint<ReplyReceivingEndpoint>();
 
-                        bridgeConfiguration.AddTransport(bridgeTransport);
+                bridgeConfiguration.AddTransport(bridgeTransport);
 
-                        bridgeConfiguration.AddTestTransportEndpoint<ReplyingEndpoint>();
-                    })
-                    .Done(c => c.SendingEndpointGotResponse)
-                    .Run();
+                bridgeConfiguration.AddTestTransportEndpoint<ReplyingEndpoint>();
+            })
+            .WithEndpoint<SendingEndpoint>(c => c
+                .When(cc => cc.EndpointsStarted, (b, _) => b.SendLocal(new StartMessage())))
+            .WithEndpoint<ReplyingEndpoint>()
+            .WithEndpoint<ReplyReceivingEndpoint>()
+            .Done(c => c.SendingEndpointGotResponse)
+            .Run();
 
         Assert.That(ctx.SendingEndpointGotResponse, Is.True);
     }

--- a/src/AcceptanceTests/Shared/Retry.cs
+++ b/src/AcceptanceTests/Shared/Retry.cs
@@ -16,12 +16,6 @@ public class Retry : BridgeAcceptanceTest
     public async Task Should_work(bool doNotTranslateReplyToAdressForFailedMessages)
     {
         var ctx = await Scenario.Define<Context>()
-            .WithEndpoint<ProcessingEndpoint>(builder =>
-            {
-                builder.DoNotFailOnErrorMessages();
-                builder.When(c => c.EndpointsStarted, (session, _) => session.SendLocal(new FaultyMessage()));
-            })
-            .WithEndpoint<FakeSCError>()
             .WithBridge(bridgeConfiguration =>
             {
                 if (doNotTranslateReplyToAdressForFailedMessages)
@@ -39,6 +33,12 @@ public class Retry : BridgeAcceptanceTest
                 theOtherTransport.AddTestEndpoint<ProcessingEndpoint>();
                 bridgeConfiguration.AddTransport(theOtherTransport);
             })
+            .WithEndpoint<ProcessingEndpoint>(builder =>
+            {
+                builder.DoNotFailOnErrorMessages();
+                builder.When(c => c.EndpointsStarted, (session, _) => session.SendLocal(new FaultyMessage()));
+            })
+            .WithEndpoint<FakeSCError>()
             .Done(c => c.GotRetrySuccessfullAck)
             .Run();
 

--- a/src/AcceptanceTests/Shared/Send_local.cs
+++ b/src/AcceptanceTests/Shared/Send_local.cs
@@ -15,18 +15,18 @@ public class Send_local : BridgeAcceptanceTest
     public async Task Should_transfer_send_local_message()
     {
         var ctx = await Scenario.Define<Context>()
-                    .WithEndpoint<OriginalEndpoint>()
-                    .WithEndpoint<MigratedEndpoint>()
-                    .WithBridge(bridgeConfiguration =>
-                    {
-                        var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
-                        bridgeTransport.HasEndpoint("_");
-                        bridgeConfiguration.AddTransport(bridgeTransport);
+            .WithBridge(bridgeConfiguration =>
+            {
+                var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
+                bridgeTransport.HasEndpoint("_");
+                bridgeConfiguration.AddTransport(bridgeTransport);
 
-                        bridgeConfiguration.AddTestTransportEndpoint(new BridgeEndpoint(OriginalEndpointName));
-                    })
-                    .Done(c => c.MessageReceived)
-                    .Run();
+                bridgeConfiguration.AddTestTransportEndpoint(new BridgeEndpoint(OriginalEndpointName));
+            })
+            .WithEndpoint<OriginalEndpoint>()
+            .WithEndpoint<MigratedEndpoint>()
+            .Done(c => c.MessageReceived)
+            .Run();
 
         Assert.That(ctx.MessageReceived, Is.True);
     }

--- a/src/AcceptanceTests/Shared/Subscribing.cs
+++ b/src/AcceptanceTests/Shared/Subscribing.cs
@@ -10,9 +10,6 @@ class Subscribing : BridgeAcceptanceTest
     public async Task Should_get_the_event()
     {
         var context = await Scenario.Define<Context>()
-            .WithEndpoint<Subscriber>()
-            .WithEndpoint<Publisher>(b => b
-                .When((session, _) => session.Publish(new MyEvent())))
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -27,6 +24,9 @@ class Subscribing : BridgeAcceptanceTest
 
                 bridgeConfiguration.AddTestTransportEndpoint<Publisher>();
             })
+            .WithEndpoint<Subscriber>()
+            .WithEndpoint<Publisher>(b => b
+                .When((session, _) => session.Publish(new MyEvent())))
             .Done(c => c.SubscriberGotEvent)
             .Run();
 

--- a/src/AcceptanceTests/Shared/Support/BridgeConfigurationExtensions.cs
+++ b/src/AcceptanceTests/Shared/Support/BridgeConfigurationExtensions.cs
@@ -5,16 +5,12 @@ using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
 public static class BridgeConfigurationExtensions
 {
     public static void AddTestEndpoint<T>(this BridgeTransport bridgeTransportConfiguration)
-        where T : EndpointConfigurationBuilder
-    {
+        where T : EndpointConfigurationBuilder =>
         bridgeTransportConfiguration.HasEndpoint(Conventions.EndpointNamingConvention(typeof(T)));
-    }
 
     public static void AddTestTransportEndpoint<T>(this BridgeConfiguration bridgeConfiguration)
-         where T : EndpointConfigurationBuilder
-    {
+         where T : EndpointConfigurationBuilder =>
         bridgeConfiguration.AddTestTransportEndpoint(new BridgeEndpoint(Conventions.EndpointNamingConvention(typeof(T))));
-    }
 
     public static void AddTestTransportEndpoint(this BridgeConfiguration bridgeConfiguration, BridgeEndpoint bridgeEndpoint)
     {

--- a/src/AcceptanceTests/Shared/ThreeTransports.cs
+++ b/src/AcceptanceTests/Shared/ThreeTransports.cs
@@ -16,11 +16,6 @@ public class ThreeTransports : BridgeAcceptanceTest
         options.SetDestination(Conventions.EndpointNamingConvention(typeof(ReceivingEndpoint)));
 
         var ctx = await Scenario.Define<Context>()
-            .WithEndpoint<ReceivingEndpoint>()
-            .WithEndpoint<EndpointOnTestingTransport>(builder => builder
-                .When(c => c.EndpointsStarted, (session, _) => session.Send(new SomeMessage { From = endpointOnTestingTransportName }, options)))
-            .WithEndpoint<EndpointOnTransportUnderTest>(builder => builder
-                .When(c => c.EndpointsStarted, (session, _) => session.Send(new SomeMessage { From = endpointOnTransportUnderTestName }, options)))
             .WithBridge(bridgeConfiguration =>
             {
                 var receivingTransport = new TestableBridgeTransport(ReceivingTestServer.GetReceivingTransportDefinition())
@@ -44,6 +39,11 @@ public class ThreeTransports : BridgeAcceptanceTest
                 transportUnderTest.AddTestEndpoint<EndpointOnTransportUnderTest>();
                 bridgeConfiguration.AddTransport(transportUnderTest);
             })
+            .WithEndpoint<ReceivingEndpoint>()
+            .WithEndpoint<EndpointOnTestingTransport>(builder => builder
+                .When(c => c.EndpointsStarted, (session, _) => session.Send(new SomeMessage { From = endpointOnTestingTransportName }, options)))
+            .WithEndpoint<EndpointOnTransportUnderTest>(builder => builder
+                .When(c => c.EndpointsStarted, (session, _) => session.Send(new SomeMessage { From = endpointOnTransportUnderTestName }, options)))
             .Done(c => c.ReceivedMessageCount == 2)
             .Run();
 

--- a/src/AcceptanceTests/Shared/TransferFailureTests.cs
+++ b/src/AcceptanceTests/Shared/TransferFailureTests.cs
@@ -16,14 +16,6 @@ public class TransferFailureTests : BridgeAcceptanceTest
     public async Task Should_add_failedq_header_when_transfer_fails()
     {
         var ctx = await Scenario.Define<Context>()
-            .WithEndpoint<ErrorSpy>()
-            .WithEndpoint<Sender>(b => b
-                .When(c => c.EndpointsStarted, async (session, c) =>
-                {
-                    var opts = new SendOptions();
-                    opts.SetHeader(FakeShovelHeader.FailureHeader, string.Empty);
-                    await session.Send(new FaultyMessage(), opts);
-                }))
             .WithBridge(bridgeConfiguration =>
             {
                 var bridgeTransport = new TestableBridgeTransport(TransportBeingTested);
@@ -34,6 +26,14 @@ public class TransferFailureTests : BridgeAcceptanceTest
                 var subscriberEndpoint = new BridgeEndpoint(ReceiveDummyQueue);
                 bridgeConfiguration.AddTestTransportEndpoint(subscriberEndpoint);
             })
+            .WithEndpoint<ErrorSpy>()
+            .WithEndpoint<Sender>(b => b
+                .When(c => c.EndpointsStarted, async (session, c) =>
+                {
+                    var opts = new SendOptions();
+                    opts.SetHeader(FakeShovelHeader.FailureHeader, string.Empty);
+                    await session.Send(new FaultyMessage(), opts);
+                }))
             .Done(c => c.MessageFailed)
             .Run();
 


### PR DESCRIPTION
This puts the bridge component into the first place in the startup order on the acceptance tests. This allows later to better manage the "transport being tested" as part of the component infrastructure, which should quite likely simplify further iterations on the code.

I'm still working out all the details, but regardless of the outcome, having a consistent order is a good thing.