### PR TITLE
Add bridge critical error action

### DIFF
--- a/src/NServiceBus.MessagingBridge/Configuration/BridgeConfiguration.cs
+++ b/src/NServiceBus.MessagingBridge/Configuration/BridgeConfiguration.cs
@@ -4,6 +4,8 @@ namespace NServiceBus
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.Extensions.Logging;
 
     /// <summary>
@@ -30,6 +32,17 @@ namespace NServiceBus
         /// Runs the bridge in receive-only transaction mode regardless of whether the bridged transports support distributed transactions
         /// </summary>
         public void RunInReceiveOnlyTransactionMode() => runInReceiveOnlyTransactionMode = true;
+
+        /// <summary>
+        /// Defines the action that the bridge performs if a critical error occurs.
+        /// </summary>
+        /// <param name="onCriticalError">The action to perform.</param>
+        public void DefineCriticalErrorAction(Func<ICriticalErrorContext, CancellationToken, Task> onCriticalError)
+        {
+            ArgumentNullException.ThrowIfNull(onCriticalError);
+
+            criticalErrorAction = onCriticalError;
+        }
 
         /// <summary>
         /// Disables the enforcement of messaging best practices (e.g. validating that an event has only one logical publisher).
@@ -165,12 +178,13 @@ namespace NServiceBus
                 transportConfiguration.TransportDefinition.TransportTransactionMode = transportTransactionMode;
             }
 
-            return new FinalizedBridgeConfiguration(transportConfigurations, translateReplyToAddressForFailedMessages);
+            return new FinalizedBridgeConfiguration(transportConfigurations, translateReplyToAddressForFailedMessages, criticalErrorAction);
         }
 
         bool runInReceiveOnlyTransactionMode;
         bool allowMultiplePublishersSameEvent;
         bool translateReplyToAddressForFailedMessages = true;
+        Func<ICriticalErrorContext, CancellationToken, Task> criticalErrorAction;
 
         readonly List<BridgeTransport> transportConfigurations = [];
     }

--- a/src/NServiceBus.MessagingBridge/Configuration/FinalizedBridgeConfiguration.cs
+++ b/src/NServiceBus.MessagingBridge/Configuration/FinalizedBridgeConfiguration.cs
@@ -1,15 +1,23 @@
 ﻿namespace NServiceBus;
 
+using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 class FinalizedBridgeConfiguration
 {
-    public FinalizedBridgeConfiguration(IReadOnlyCollection<BridgeTransport> transportConfigurations, bool translateReplyToAddressForFailedMessages)
+    public FinalizedBridgeConfiguration(
+        IReadOnlyCollection<BridgeTransport> transportConfigurations,
+        bool translateReplyToAddressForFailedMessages,
+        Func<ICriticalErrorContext, CancellationToken, Task> criticalErrorAction = null)
     {
         TransportConfigurations = transportConfigurations;
         TranslateReplyToAddressForFailedMessages = translateReplyToAddressForFailedMessages;
+        CriticalErrorAction = criticalErrorAction;
     }
 
     public IReadOnlyCollection<BridgeTransport> TransportConfigurations { get; }
     public bool TranslateReplyToAddressForFailedMessages { get; }
+    public Func<ICriticalErrorContext, CancellationToken, Task> CriticalErrorAction { get; }
 }

--- a/src/NServiceBus.MessagingBridge/EndpointProxyFactory.cs
+++ b/src/NServiceBus.MessagingBridge/EndpointProxyFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 using NServiceBus;
 using NServiceBus.Raw;
 
-class EndpointProxyFactory(IServiceProvider serviceProvider)
+class EndpointProxyFactory(IServiceProvider serviceProvider, FinalizedBridgeConfiguration bridgeConfiguration)
 {
     public Task<IStartableRawEndpoint> CreateProxy(
         BridgeEndpoint endpointToProxy,
@@ -45,6 +45,11 @@ class EndpointProxyFactory(IServiceProvider serviceProvider)
             transportEndpointConfiguration.AutoCreateQueues();
         }
 
+        if (bridgeConfiguration.CriticalErrorAction != null)
+        {
+            transportEndpointConfiguration.CriticalErrorAction(bridgeConfiguration.CriticalErrorAction);
+        }
+
         transportEndpointConfiguration.LimitMessageProcessingConcurrencyTo(transportConfiguration.Concurrency);
         transportEndpointConfiguration.CustomErrorHandlingPolicy(new MessageShovelErrorHandlingPolicy(
             serviceProvider.GetRequiredService<ILogger<MessageShovelErrorHandlingPolicy>>()));
@@ -52,9 +57,14 @@ class EndpointProxyFactory(IServiceProvider serviceProvider)
         return RawEndpoint.Create(transportEndpointConfiguration, cancellationToken);
     }
 
-    public static Task<IStartableRawEndpoint> CreateDispatcher(BridgeTransport transportConfiguration, CancellationToken cancellationToken = default)
+    public Task<IStartableRawEndpoint> CreateDispatcher(BridgeTransport transportConfiguration, CancellationToken cancellationToken = default)
     {
         var endpointConfiguration = RawEndpointConfiguration.CreateSendOnly($"bridge-dispatcher-{transportConfiguration.Name}", transportConfiguration.TransportDefinition);
+
+        if (bridgeConfiguration.CriticalErrorAction != null)
+        {
+            endpointConfiguration.CriticalErrorAction(bridgeConfiguration.CriticalErrorAction);
+        }
 
         return RawEndpoint.Create(endpointConfiguration, cancellationToken);
     }

--- a/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
+++ b/src/NServiceBus.MessagingBridge/EndpointRegistry.cs
@@ -48,7 +48,7 @@ class EndpointRegistry(EndpointProxyFactory endpointProxyFactory, ILogger<Starta
     {
         foreach (var transport in transportConfigurations)
         {
-            var dispatcher = await EndpointProxyFactory.CreateDispatcher(transport, cancellationToken).ConfigureAwait(false);
+            var dispatcher = await endpointProxyFactory.CreateDispatcher(transport, cancellationToken).ConfigureAwait(false);
             dispatchers.Add(transport.Name, dispatcher);
             proxyRegistrations.Add(new ProxyRegistration
             {

--- a/src/UnitTests/ApprovalFiles/APIApprovals.PublicApi.approved.txt
+++ b/src/UnitTests/ApprovalFiles/APIApprovals.PublicApi.approved.txt
@@ -6,6 +6,7 @@ namespace NServiceBus
     {
         public BridgeConfiguration() { }
         public void AddTransport(NServiceBus.BridgeTransport transportConfiguration) { }
+        public void DefineCriticalErrorAction(System.Func<NServiceBus.ICriticalErrorContext, System.Threading.CancellationToken, System.Threading.Tasks.Task> onCriticalError) { }
         public void DoNotEnforceBestPractices() { }
         public void DoNotTranslateReplyToAddressForFailedMessages() { }
         public void RunInReceiveOnlyTransactionMode() { }

--- a/src/UnitTests/BridgeConfigurationTests.cs
+++ b/src/UnitTests/BridgeConfigurationTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using NServiceBus;
 using NUnit.Framework;
 using UnitTests;
@@ -74,6 +76,36 @@ public class BridgeConfigurationTests
         var transport = new BridgeTransport(new SomeTransport());
 
         Assert.That(transport.Concurrency, Is.EqualTo(Math.Max(2, Environment.ProcessorCount)));
+    }
+
+    [Test]
+    public void Should_not_allow_null_critical_error_action()
+    {
+        var configuration = new BridgeConfiguration();
+
+        Assert.Throws<ArgumentNullException>(() => configuration.DefineCriticalErrorAction(null));
+    }
+
+    [Test]
+    public void Should_store_critical_error_action()
+    {
+        var configuration = new BridgeConfiguration();
+
+        var someTransport = new BridgeTransport(new SomeTransport());
+        someTransport.HasEndpoint("Sales");
+        configuration.AddTransport(someTransport);
+
+        var someOtherTransport = new BridgeTransport(new SomeOtherTransport());
+        someOtherTransport.HasEndpoint("Billing");
+        configuration.AddTransport(someOtherTransport);
+
+        Func<ICriticalErrorContext, CancellationToken, Task> onCriticalError = (_, __) => Task.CompletedTask;
+
+        configuration.DefineCriticalErrorAction(onCriticalError);
+
+        var finalizedConfiguration = FinalizeConfiguration(configuration);
+
+        Assert.That(finalizedConfiguration.CriticalErrorAction, Is.EqualTo(onCriticalError));
     }
 
     [Test]

--- a/src/UnitTests/EndpointProxyFactoryTests.cs
+++ b/src/UnitTests/EndpointProxyFactoryTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NServiceBus;
+using NServiceBus.Raw;
+using NServiceBus.Transport;
+using NUnit.Framework;
+using UnitTests;
+
+public class EndpointProxyFactoryTests
+{
+    [TestCase(EndpointKind.Dispatcher)]
+    [TestCase(EndpointKind.Proxy)]
+    public async Task Should_invoke_configured_critical_error_action_when_transport_raises_critical_error(EndpointKind endpointKind)
+    {
+        var criticalErrorContext = new TaskCompletionSource<ICriticalErrorContext>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var exception = new Exception("Something failed");
+
+        Task OnCriticalError(ICriticalErrorContext context, CancellationToken cancellationToken)
+        {
+            criticalErrorContext.SetResult(context);
+            return Task.CompletedTask;
+        }
+
+        var bridgeConfiguration = new FinalizedBridgeConfiguration([], false, OnCriticalError);
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<IMessageShovel>(new TestMessageShovel())
+            .AddSingleton<ILogger<MessageShovelErrorHandlingPolicy>>(new FakeLogger<MessageShovelErrorHandlingPolicy>())
+            .BuildServiceProvider();
+        var endpointProxyFactory = new EndpointProxyFactory(serviceProvider, bridgeConfiguration);
+        var transport = new CriticalErrorCapturingTransport();
+        var bridgeTransport = new BridgeTransport(transport);
+        var startableEndpoint = endpointKind == EndpointKind.Dispatcher
+            ? await endpointProxyFactory.CreateDispatcher(bridgeTransport, CancellationToken.None)
+            : await endpointProxyFactory.CreateProxy(new BridgeEndpoint("Sales"), bridgeTransport, CancellationToken.None);
+
+        var runningEndpoint = await startableEndpoint.Start(CancellationToken.None);
+
+        transport.RaiseCriticalError("Critical error", exception, CancellationToken.None);
+
+        var context = await criticalErrorContext.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.Error, Is.EqualTo("Critical error"));
+            Assert.That(context.Exception, Is.SameAs(exception));
+        });
+
+        await runningEndpoint.Stop(CancellationToken.None);
+    }
+
+    public enum EndpointKind
+    {
+        Dispatcher,
+        Proxy
+    }
+
+    class CriticalErrorCapturingTransport : TransportDefinition
+    {
+        public CriticalErrorCapturingTransport()
+            : base(TransportTransactionMode.ReceiveOnly, true, true, true)
+        {
+        }
+
+        public override IReadOnlyCollection<TransportTransactionMode> GetSupportedTransactionModes() =>
+        [
+            TransportTransactionMode.ReceiveOnly
+        ];
+
+        public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken = default)
+        {
+            criticalErrorAction = hostSettings.CriticalErrorAction;
+
+            return Task.FromResult<TransportInfrastructure>(new TestTransportInfrastructure(receivers));
+        }
+
+        public void RaiseCriticalError(string message, Exception exception, CancellationToken cancellationToken = default) =>
+            criticalErrorAction(message, exception, cancellationToken);
+
+        Action<string, Exception, CancellationToken> criticalErrorAction;
+    }
+
+    class TestTransportInfrastructure : TransportInfrastructure
+    {
+        public TestTransportInfrastructure(ReceiveSettings[] receiverSettings)
+        {
+            Dispatcher = new TestMessageDispatcher();
+            var receivers = new Dictionary<string, IMessageReceiver>();
+            foreach (var receiverSetting in receiverSettings)
+            {
+                receivers.Add(receiverSetting.Id, new TestMessageReceiver(receiverSetting.Id));
+            }
+
+            Receivers = receivers;
+        }
+
+        public override Task Shutdown(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public override string ToTransportAddress(QueueAddress address) => address.ToString();
+    }
+
+    class TestMessageDispatcher : IMessageDispatcher
+    {
+        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    class TestMessageReceiver(string id) : IMessageReceiver
+    {
+        public Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task StartReceive(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task ChangeConcurrency(PushRuntimeSettings limitations, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task StopReceive(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public ISubscriptionManager Subscriptions => null;
+
+        public string Id { get; } = id;
+
+        public string ReceiveAddress { get; } = id;
+    }
+
+    class TestMessageShovel : IMessageShovel
+    {
+        public Task TransferMessage(TransferContext transferContext, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a public `BridgeConfiguration.DefineCriticalErrorAction(...)` API so bridge hosts can configure a response to critical errors using the same delegate shape as regular NServiceBus endpoints.

The configured action is stored in the finalized bridge configuration and applied to the raw endpoint configuration for both bridge proxy endpoints and send-only dispatcher endpoints. This keeps the action wired through transport `HostSettings.CriticalErrorAction`, matching the convention used by NServiceBus Core.

## Testing

- Added bridge configuration tests for null handler validation and finalized configuration storage.
- Added endpoint proxy factory tests that use a fake transport to raise critical errors through `HostSettings.CriticalErrorAction` for both dispatcher and proxy raw endpoints.
- Updated public API approval for the additive API change.
