### PR TITLE
Run IBMMQ on Windows too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
         exclude:
           - os: ubuntu-latest
             transport: MSMQ
-          - os: windows-latest
-            transport: IBMMQ
       fail-fast: false
     steps:
       - name: Check for secrets


### PR DESCRIPTION
Removed Windows transport exclusions from CI workflow.